### PR TITLE
SECOFS-UFS-DATM-VALIDATION: add DATM forcing validation + sflux-vs-DA…

### DIFF
--- a/SECOFS-UFS-DATM-VALIDATION/analyze_hrrr_posting.py
+++ b/SECOFS-UFS-DATM-VALIDATION/analyze_hrrr_posting.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+Turn HRRR file posting times into a prep-cron recommendation.
+
+Input CSV (capture on WCOSS2): columns  pdy,cyc,fhr,mtime_epoch
+  for f in .../hrrr.tCYz.wrfsfcf*.grib2: echo "$PDY,$CYC,$fhr,$(stat -c %Y "$f")"
+
+For each cycle it prints when key forecast hours posted (lag from cycle time),
+the f48 lag, and a recommended prep-cron offset = f48_lag + BUFFER.
+
+Usage:  python3 analyze_hrrr_posting.py hrrr_posting_20260605.csv [more.csv ...]
+"""
+import csv
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+
+NEED_FHR = 48        # last forecast hour SECOFS needs (forecast_hours)
+BUFFER_MIN = 15      # safety margin added on top of the f48 posting lag
+MILESTONES = [18, 28, 36, 48]
+
+
+def cyc_epoch(pdy, cyc):
+    return datetime.strptime(f"{pdy}{int(cyc):02d}", "%Y%m%d%H").replace(
+        tzinfo=timezone.utc).timestamp()
+
+
+def load(paths):
+    rows = defaultdict(dict)   # (pdy,cyc) -> {fhr: mtime_epoch}
+    for p in paths:
+        with open(p) as fh:
+            for r in csv.DictReader(fh):
+                rows[(r["pdy"], r["cyc"])][int(r["fhr"])] = float(r["mtime_epoch"])
+    return rows
+
+
+def fmt_lag(sec):
+    sec = int(sec)
+    return f"+{sec//3600}h{(sec%3600)//60:02d}m"
+
+
+def main(paths):
+    rows = load(paths)
+    worst_f48 = 0.0
+    print(f"{'cycle':14} | " + " | ".join(f"f{n:02d}" for n in MILESTONES)
+          + " | f48 lag | rec. cron offset")
+    print("-" * 86)
+    for (pdy, cyc), fhrs in sorted(rows.items()):
+        c0 = cyc_epoch(pdy, cyc)
+        cells = []
+        for n in MILESTONES:
+            cells.append(fmt_lag(fhrs[n] - c0) if n in fhrs else "  --  ")
+        if NEED_FHR in fhrs:
+            lag = fhrs[NEED_FHR] - c0
+            worst_f48 = max(worst_f48, lag)
+            rec = fmt_lag(lag + BUFFER_MIN * 60)
+            f48 = fmt_lag(lag)
+        else:
+            f48, rec = "MISSING", "n/a (f48 not posted)"
+        print(f"{pdy} t{int(cyc):02d}z | " + " | ".join(f"{c:>6}" for c in cells)
+              + f" | {f48:>7} | {rec}")
+    print("-" * 86)
+    if worst_f48:
+        rec_min = int(worst_f48 / 60) + BUFFER_MIN
+        print(f"Worst-case f48 across the sampled cycles: {fmt_lag(worst_f48)}")
+        print(f"=> set prep cron to fire >= +{rec_min} min after cycle "
+              f"(f48 lag + {BUFFER_MIN}min buffer).")
+        print("   Capture a few more days to size the buffer against slow HRRR runs.")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        sys.exit("usage: analyze_hrrr_posting.py <hrrr_posting_*.csv> ...")
+    main(sys.argv[1:])

--- a/SECOFS-UFS-DATM-VALIDATION/plot_windspeed_sequence_hrrr_ufs.py
+++ b/SECOFS-UFS-DATM-VALIDATION/plot_windspeed_sequence_hrrr_ufs.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""
+Wind speed comparison for the latest SECOFS run (cycle 20260604):
+SCHISM sflux (HRRR nest) vs UFS-coastal DATM forcing (blended GFS+HRRR),
+one 3-panel frame per matched timestep.
+
+  Left   : SCHISM sflux (HRRR)   (uwind/vwind from sflux_air_2.*.nc, HRRR nest grid)
+  Middle : UFS DATM (blended)    (UGRD/VGRD_10maboveground from datm_forcing.nc, native blended grid)
+  Right  : Difference            (DATM regridded onto the sflux grid, DATM - sflux)
+
+The two products live on different grids (sflux=HRRR nest 745x630, DATM=blended 0.025 deg),
+so the difference panel interpolates the DATM field onto the sflux grid before subtracting.
+Consistent colorbars across all frames.
+"""
+
+import sys
+import tarfile
+import argparse
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.lines import Line2D
+import numpy as np
+from netCDF4 import Dataset, num2date
+from scipy.interpolate import RegularGridInterpolator
+
+# ---- defaults (used with NO CLI args; the original E: V21 example run) -------
+DEFAULT_DATM = ("/mnt/e/secofs_com_outs/PYTHON_V14/V21/"
+                "secofs_ufs.t06z.datm_input/datm_forcing.nc")
+DEFAULT_SFLUX_SRC = "/mnt/e/secofs_com_outs/PYTHON_V14/V21"
+DEFAULT_OUT_BASE = "/mnt/e/secofs_com_outs/comparison_v390_vs_python"
+DEFAULT_CYC, DEFAULT_PDY = 6, "20260606"
+
+# Populated by _apply_args() before main() runs; CLI args override the defaults.
+#   nest 1 = GFS  (sflux_air_1, met.*.nc.tar,   coarse 0.5 deg)
+#   nest 2 = HRRR (sflux_air_2, met.*.nc.2.tar, fine 3km)
+SFLUX_SRC = DATM_FILE = OUT = CYCLE = None
+SFLUX_TARS = []
+SFLUX_NEST = 2
+SFLUX_LABEL = "HRRR"
+
+MATCH_TOL_HOURS = 0.5   # match sflux<->DATM timesteps within 30 min
+FRAME_STRIDE_HOURS = 3  # emit a frame roughly every 3 hours
+
+
+def _apply_args():
+    """Parse CLI args and populate the module globals used throughout."""
+    global SFLUX_SRC, DATM_FILE, OUT, CYCLE, SFLUX_TARS, SFLUX_NEST, SFLUX_LABEL
+    global FRAME_STRIDE_HOURS
+    ap = argparse.ArgumentParser(
+        description="3-panel SCHISM-sflux vs UFS-DATM wind-speed comparison frames.")
+    ap.add_argument("--datm", default=DEFAULT_DATM, help="path to datm_forcing.nc")
+    ap.add_argument("--sflux-src", default=DEFAULT_SFLUX_SRC,
+                    help="dir with the <prefix>.t<cyc>z.<pdy>.met.*.tar files")
+    ap.add_argument("--cyc", type=int, default=DEFAULT_CYC, help="cycle hour")
+    ap.add_argument("--pdy", default=DEFAULT_PDY, help="YYYYMMDD")
+    ap.add_argument("--nest", type=int, choices=(1, 2), default=2,
+                    help="1=GFS sflux_air_1, 2=HRRR sflux_air_2 (default 2)")
+    ap.add_argument("--sflux-prefix", default="secofs",
+                    help="sflux tar prefix (default 'secofs')")
+    ap.add_argument("--out", default=None,
+                    help="output dir (default <OUT_BASE>/sflux<nest>_<label>_vs_datm_<pdy>_<cyc>z)")
+    ap.add_argument("--stride-hours", type=float, default=FRAME_STRIDE_HOURS,
+                    help="emit a frame every N hours (default 3)")
+    a = ap.parse_args()
+    SFLUX_NEST = a.nest
+    SFLUX_LABEL = "GFS" if a.nest == 1 else "HRRR"
+    suffix = "" if a.nest == 1 else ".2"
+    SFLUX_SRC = Path(a.sflux_src)
+    DATM_FILE = Path(a.datm)
+    CYCLE = datetime.strptime(a.pdy, "%Y%m%d") + timedelta(hours=a.cyc)
+    FRAME_STRIDE_HOURS = a.stride_hours
+    SFLUX_TARS = [
+        f"{a.sflux_prefix}.t{a.cyc:02d}z.{a.pdy}.met.nowcast.nc{suffix}.tar",
+        f"{a.sflux_prefix}.t{a.cyc:02d}z.{a.pdy}.met.forecast.nc{suffix}.tar",
+    ]
+    OUT = Path(a.out) if a.out else (
+        Path(DEFAULT_OUT_BASE)
+        / f"sflux{a.nest}_{SFLUX_LABEL.lower()}_vs_datm_{a.pdy}_{a.cyc:02d}z")
+
+
+def extract(tar_path):
+    tmp = tempfile.mkdtemp(prefix="sflux_")
+    with tarfile.open(str(tar_path)) as tf:
+        tf.extractall(tmp, filter="data")
+    return Path(tmp)
+
+
+def load_comf(tar_names):
+    """Concatenate sflux_air_2 uwind/vwind across the listed sflux tars."""
+    times, us, vs = [], [], []
+    lon = lat = None
+    for tn in tar_names:
+        tar = SFLUX_SRC / tn
+        if not tar.exists():
+            print(f"  [skip] missing {tar}")
+            continue
+        d = extract(tar)
+        for p in sorted(d.glob(f"sflux_air_{SFLUX_NEST}.*.nc")):
+            ds = Dataset(str(p))
+            if lon is None:
+                lon = np.array(ds.variables["lon"][:])
+                lat = np.array(ds.variables["lat"][:])
+            tvar = ds.variables["time"]
+            tdt = num2date(tvar[:], tvar.units,
+                           only_use_cftime_datetimes=False,
+                           only_use_python_datetimes=True)
+            times.append(np.array(tdt))
+            us.append(np.array(ds.variables["uwind"][:]))
+            vs.append(np.array(ds.variables["vwind"][:]))
+            ds.close()
+    return {
+        "time": np.concatenate(times),
+        "u": np.concatenate(us, axis=0),
+        "v": np.concatenate(vs, axis=0),
+        "lon": lon, "lat": lat,
+    }
+
+
+def load_datm(path):
+    """Read blended UGRD/VGRD plus coords + time from the UFS DATM file."""
+    ds = Dataset(str(path))
+    uname = "UGRD_10maboveground" if "UGRD_10maboveground" in ds.variables else None
+    vname = "VGRD_10maboveground" if "VGRD_10maboveground" in ds.variables else None
+    if uname is None:  # fall back to any u/v 10m naming
+        for cand in ("uwind", "u10", "Uwind", "UGRD"):
+            if cand in ds.variables:
+                uname = cand
+                break
+        for cand in ("vwind", "v10", "Vwind", "VGRD"):
+            if cand in ds.variables:
+                vname = cand
+                break
+    lonv = ds.variables["longitude"] if "longitude" in ds.variables else ds.variables["lon"]
+    latv = ds.variables["latitude"] if "latitude" in ds.variables else ds.variables["lat"]
+    lon = np.array(lonv[:])
+    lat = np.array(latv[:])
+    tvar = ds.variables["time"]
+    tdt = num2date(tvar[:], tvar.units,
+                   only_use_cftime_datetimes=False,
+                   only_use_python_datetimes=True)
+    src = np.array(ds.variables["data_source"][:]) if "data_source" in ds.variables else None
+    # NOTE: do NOT load full UGRD/VGRD (5.5 GB file -> ~1.4 GB + page-cache blowup
+    # over the /mnt drvfs mount can wedge WSL2). Keep the dataset open and read
+    # one timestep at a time in the frame loop; caller closes it.
+    return {"time": np.array(tdt), "ds": ds, "uname": uname, "vname": vname,
+            "lon": lon, "lat": lat, "src": src}
+
+
+def datm_uv(p, i):
+    """Read a single DATM timestep's (u, v) as float64 (small hyperslab read)."""
+    u = np.asarray(p["ds"].variables[p["uname"]][i], dtype=np.float64)
+    v = np.asarray(p["ds"].variables[p["vname"]][i], dtype=np.float64)
+    return u, v
+
+
+def axes_1d(lon2d, lat2d):
+    """Return (lon_axis, lat_axis, increasing_flags) for a regular 2D coord pair."""
+    if lon2d.ndim == 1:
+        return lon2d, lat2d
+    lon_axis = lon2d[0, :]
+    lat_axis = lat2d[:, 0]
+    return lon_axis, lat_axis
+
+
+def regrid_to_comf(datm_field, datm_lon, datm_lat, comf_lon, comf_lat):
+    """Interpolate a DATM (y,x) field onto COMF grid points. DATM is regular lat/lon."""
+    lon_axis, lat_axis = axes_1d(datm_lon, datm_lat)
+    # RegularGridInterpolator needs strictly increasing axes
+    flip_lat = lat_axis[0] > lat_axis[-1]
+    flip_lon = lon_axis[0] > lon_axis[-1]
+    la = lat_axis[::-1] if flip_lat else lat_axis
+    lo = lon_axis[::-1] if flip_lon else lon_axis
+    f = datm_field
+    if flip_lat:
+        f = f[::-1, :]
+    if flip_lon:
+        f = f[:, ::-1]
+    interp = RegularGridInterpolator((la, lo), f, bounds_error=False, fill_value=np.nan)
+    pts = np.stack([comf_lat.ravel(), comf_lon.ravel()], axis=-1)
+    return interp(pts).reshape(comf_lon.shape)
+
+
+def match_times(t_comf, t_datm, tol_hours):
+    pairs = []
+    for i, tc in enumerate(t_comf):
+        best_j, best_d = None, None
+        for j, td in enumerate(t_datm):
+            d = abs((tc - td).total_seconds()) / 3600.0
+            if best_d is None or d < best_d:
+                best_d, best_j = d, j
+        if best_d is not None and best_d < tol_hours:
+            pairs.append((i, best_j))
+    return pairs
+
+
+def main():
+    if not DATM_FILE.exists():
+        sys.exit(f"DATM file not present yet: {DATM_FILE}")
+    OUT.mkdir(parents=True, exist_ok=True)
+
+    print("Loading SCHISM sflux_air_2 (HRRR) ...")
+    c = load_comf(SFLUX_TARS)
+    # nowcast/forecast sflux tars OVERLAP in time, and carry DIFFERENT data at
+    # the overlap (each prep phase pulls its own GFS cycle -- can differ by
+    # several m/s). The DATM file is the forecast-phase product, so prefer the
+    # forecast-phase sflux (last tar listed) at overlapping timestamps; keeping
+    # the nowcast one produces a spurious non-zero diff in the GFS region.
+    last_idx = {}
+    for i, t in enumerate(c["time"]):
+        last_idx[t.replace(microsecond=0)] = i   # later tar overwrites -> forecast wins
+    order = np.array([last_idx[k] for k in sorted(last_idx)])
+    c["time"], c["u"], c["v"] = c["time"][order], c["u"][order], c["v"][order]
+    print(f"  sflux: {len(c['time'])} unique steps, grid {c['u'].shape[1:]}, "
+          f"{c['time'][0]} .. {c['time'][-1]}")
+
+    print("Loading UFS DATM forcing ...")
+    p = load_datm(DATM_FILE)
+    print(f"  DATM: {len(p['time'])} steps, grid {p['lon'].shape}, "
+          f"{p['time'][0]} .. {p['time'][-1]}")
+
+    # --- date-coverage sanity check -------------------------------------------
+    overlap_lo = max(c["time"][0], p["time"][0])
+    overlap_hi = min(c["time"][-1], p["time"][-1])
+    if overlap_hi < overlap_lo:
+        print("\n*** WARNING: sflux and DATM time windows DO NOT OVERLAP ***")
+        print(f"    sflux: {c['time'][0]} .. {c['time'][-1]}")
+        print(f"    DATM:  {p['time'][0]} .. {p['time'][-1]}")
+        print("    The two products are from different cycles -- "
+              "differences would be meaningless. Aborting.")
+        sys.exit(2)
+    print(f"  Overlap window: {overlap_lo} .. {overlap_hi}")
+
+    matches = match_times(c["time"], p["time"], MATCH_TOL_HOURS)
+    print(f"Matched timesteps: {len(matches)}")
+    if not matches:
+        sys.exit("No matching timesteps within tolerance.")
+
+    # stride to ~FRAME_STRIDE_HOURS
+    if len(matches) > 1:
+        dt_h = abs((c["time"][matches[1][0]] - c["time"][matches[0][0]]).total_seconds()) / 3600.0
+        step = max(1, round(FRAME_STRIDE_HOURS / dt_h)) if dt_h > 0 else 1
+    else:
+        step = 1
+    selected = matches[::step]
+    print(f"Selected {len(selected)} frames (stride={step})")
+
+    comf_lon, comf_lat = c["lon"], c["lat"]
+
+    # DATM cells inside the sflux footprint -- used to gauge effective resolution
+    win = ((p["lon"] >= float(comf_lon.min())) & (p["lon"] <= float(comf_lon.max())) &
+           (p["lat"] >= float(comf_lat.min())) & (p["lat"] <= float(comf_lat.max())))
+    # sharpness (mean |grad ws|) cleanly separates HRRR (~0.2) from GFS fallback (~0.07)
+    SHARP_THRESH = 0.13
+
+    # precompute regridded DATM ws + global scales
+    print("Regridding DATM -> COMF grid for each selected frame ...")
+    ws_comf, ws_datm_native, ws_datm_on_comf, datm_src = [], [], [], []
+    for ic, ip in selected:
+        wc = np.hypot(c["u"][ic].astype(np.float64), c["v"][ic].astype(np.float64))
+        up, vp = datm_uv(p, ip)
+        wd_native = np.hypot(up, vp)
+        wd_on_comf = regrid_to_comf(wd_native, p["lon"], p["lat"], comf_lon, comf_lat)
+        gy, gx = np.gradient(np.where(win, wd_native, np.nan))
+        sharp = float(np.nanmean(np.hypot(gy, gx)))
+        datm_src.append("HRRR (fine)" if sharp > SHARP_THRESH else "GFS fallback (coarse)")
+        ws_comf.append(wc)
+        ws_datm_native.append(wd_native)
+        ws_datm_on_comf.append(wd_on_comf)
+
+    ws_vmax = np.ceil(max(
+        max(np.nanmax(a) for a in ws_comf),
+        max(np.nanmax(a) for a in ws_datm_native),
+    ))
+    diff_max = max(np.nanmax([np.nanmax(np.abs(d - c_)) for d, c_ in
+                              zip(ws_datm_on_comf, ws_comf)]), 0.1)
+    diff_max = np.ceil(diff_max * 10) / 10
+    print(f"Wind speed range: [0, {ws_vmax:.1f}] m/s; diff +/- {diff_max:.2f} m/s")
+
+    d_lon, d_lat = p["lon"], p["lat"]
+    # Coarsened HRRR/GFS boundary for the overlay contour: the full 1721^2
+    # contour exceeds the memory cap, and the boundary is smooth, so a 4x
+    # stride is plenty. Computed once (data_source is time-invariant).
+    if p["src"] is not None:
+        cs = slice(None, None, 4)
+        src_c, slon_c, slat_c = p["src"][cs, cs], p["lon"][cs, cs], p["lat"][cs, cs]
+    else:
+        src_c = slon_c = slat_c = None
+    for frame, (ic, ip) in enumerate(selected):
+        tc = c["time"][ic]
+        vt_str = tc.strftime("%Y-%m-%d %H:%MZ")
+        stage = "Nowcast" if tc <= CYCLE else "Forecast"
+
+        wc = ws_comf[frame]
+        wd = ws_datm_native[frame]
+        diff = ws_datm_on_comf[frame] - wc
+        rmse = float(np.sqrt(np.nanmean(diff ** 2)))
+
+        fig, axes = plt.subplots(1, 3, figsize=(21, 6), constrained_layout=True)
+
+        im0 = axes[0].pcolormesh(comf_lon, comf_lat, wc, vmin=0, vmax=ws_vmax,
+                                 cmap="YlOrRd", shading="auto")
+        axes[0].set_title(f"SCHISM sflux ({SFLUX_LABEL})", fontsize=12)
+        plt.colorbar(im0, ax=axes[0], label="Wind Speed (m/s)", fraction=0.046, pad=0.04)
+
+        im1 = axes[1].pcolormesh(d_lon, d_lat, wd, vmin=0, vmax=ws_vmax,
+                                 cmap="YlOrRd", shading="auto")
+        axes[1].set_title(f"UFS DATM (blended) - source: {datm_src[frame]}", fontsize=12)
+        plt.colorbar(im1, ax=axes[1], label="Wind Speed (m/s)", fraction=0.046, pad=0.04)
+
+        im2 = axes[2].pcolormesh(comf_lon, comf_lat, diff, vmin=-diff_max, vmax=diff_max,
+                                 cmap="bwr", shading="auto")
+        axes[2].set_title(f"Difference (RMSE={rmse:.3f} m/s)", fontsize=12)
+        plt.colorbar(im2, ax=axes[2], label="DATM - sflux (m/s)", fraction=0.046, pad=0.04)
+
+        # Overlay HRRR/GFS boundary (data_source=0.5 contour). Inside the line the
+        # DATM uses HRRR; outside it falls back to GFS -> diff should go quiet there.
+        if src_c is not None:
+            for ax in (axes[1], axes[2]):
+                ax.contour(slon_c, slat_c, src_c, levels=[0.5],
+                           colors="black", linewidths=0.8)
+            axes[2].legend([Line2D([0], [0], color="black", lw=0.8)],
+                           ["HRRR domain edge"], loc="lower left", fontsize=8)
+
+        for ax in axes:
+            ax.set_xlabel("Longitude")
+            ax.set_ylabel("Latitude")
+            ax.set_xlim(float(comf_lon.min()), float(comf_lon.max()))
+            ax.set_ylim(float(comf_lat.min()), float(comf_lat.max()))
+
+        fig.suptitle(f"Wind Speed: SCHISM sflux vs UFS DATM  -  {vt_str}  ({stage})",
+                     fontsize=15, fontweight="bold")
+
+        fname = f"windspeed_{frame:03d}_{tc.strftime('%Y%m%d_%H%M')}.png"
+        fig.savefig(OUT / fname, dpi=130)
+        plt.close(fig)
+        print(f"  {fname}  (RMSE={rmse:.3f})")
+
+    p["ds"].close()
+    print(f"\nSaved {len(selected)} frames to: {OUT}")
+
+
+if __name__ == "__main__":
+    _apply_args()
+    main()

--- a/SECOFS-UFS-DATM-VALIDATION/validate_datm_wcoss2.py
+++ b/SECOFS-UFS-DATM-VALIDATION/validate_datm_wcoss2.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""
+Validate a SECOFS-UFS DATM forcing run ON WCOSS2 (no plotting required).
+
+Designed for WCOSS2's limited python: it degrades gracefully by what is
+importable.
+
+  CHECK 1 - MANIFEST  (Python standard library only -> runs on ANY python)
+      Reads <ofs>.t<cyc>z.<pdy>.inputs.prep.json and inspects the HRRR file
+      list that fed the DATM blend:
+        * first HRRR file should be valid AT model_t0 (= cyc - nowcast_hours)
+          -> confirms the t0 fix (nos-utils #29)
+        * last  HRRR file should reach cyc + forecast_hours
+          -> confirms the cron-timing / full-coverage fix
+        * prints prep timing (generated_at - cycle)
+
+  CHECK 2 - DATM      (needs numpy + netCDF4, present in the prep python env)
+      Reads datm_forcing.nc and, per timestep, measures wind-speed sharpness
+      over the HRRR-coverage cells (data_source==1). Fine HRRR ~0.2, coarse
+      GFS ~0.06. Confirms t0 is HRRR and coverage runs to +forecast_hours.
+
+USAGE on WCOSS2:
+    module load python/3.8.6                 # same python the prep uses
+    COMOUT=/path/to/com/.../secofs_ufs.<pdy>
+    python3 validate_datm_wcoss2.py \
+        --manifest $COMOUT/secofs_ufs.t06z.20260606.inputs.prep.json \
+        --datm     $COMOUT/secofs_ufs.t06z.datm_input/datm_forcing.nc \
+        --cyc 6 --pdy 20260606 --nowcast-hours 6 --forecast-hours 48
+
+Either --manifest or --datm may be given alone. --cyc/--pdy are read from the
+manifest when present, so for a manifest-only run you can omit them.
+"""
+import argparse
+import datetime as dt
+import json
+import re
+import sys
+
+SHARP_THRESH = 0.13       # fine HRRR (~0.2) vs coarse GFS (~0.06) on the 0.025deg grid
+OK, BAD = "PASS", "FAIL"
+
+
+# --------------------------------------------------------------------------
+# CHECK 1: manifest (stdlib only)
+# --------------------------------------------------------------------------
+def parse_hrrr(path):
+    """hrrr.YYYYMMDD/.../hrrr.tHHz.wrfsfcfFF.grib2 -> (valid_datetime, cyc, fhr)."""
+    m = re.search(r"hrrr\.(\d{8})/.*?hrrr\.t(\d{2})z\.wrfsfcf(\d{2,3})", path)
+    if not m:
+        return None
+    base = dt.datetime.strptime(m.group(1), "%Y%m%d") + dt.timedelta(hours=int(m.group(2)))
+    return base + dt.timedelta(hours=int(m.group(3))), int(m.group(2)), int(m.group(3))
+
+
+def check_manifest(path, nowcast_hours, forecast_hours):
+    with open(path) as fh:
+        man = json.load(fh)
+    pdy, cyc = man["pdy"], int(man["cyc"])
+    cycle = dt.datetime.strptime(pdy, "%Y%m%d") + dt.timedelta(hours=cyc)
+    model_t0 = cycle - dt.timedelta(hours=nowcast_hours)
+    want_last = cycle + dt.timedelta(hours=forecast_hours)
+
+    hrrr = [e for e in man["inputs"] if (e.get("source") or "").upper() == "HRRR"]
+    files = hrrr[0]["files"] if hrrr else []
+    parsed = sorted(filter(None, (parse_hrrr(f) for f in files)), key=lambda x: x[0])
+
+    print("=" * 70)
+    print(f"CHECK 1  MANIFEST  {pdy} t{cyc:02d}z")
+    print("=" * 70)
+    gen = man.get("generated_at")
+    if gen:
+        try:
+            off = (dt.datetime.fromisoformat(gen) - cycle.replace(tzinfo=dt.timezone.utc)).total_seconds() / 3600
+            print(f"  prep generated_at : {gen}  (+{off:.2f}h after cycle)")
+        except Exception:
+            print(f"  prep generated_at : {gen}")
+    print(f"  HRRR files        : {len(files)}")
+    if not parsed:
+        print(f"  {BAD}: no HRRR files in manifest")
+        return False
+
+    first_valid, _, _ = parsed[0]
+    last_valid, last_cyc, last_fhr = parsed[-1]
+    t0_ok = first_valid == model_t0
+    cov_ok = last_valid >= want_last
+    print(f"  first HRRR valid  : {first_valid:%Y-%m-%d %H:%M}  "
+          f"(want model_t0 {model_t0:%Y-%m-%d %H:%M})  -> {OK if t0_ok else BAD}")
+    print(f"  last  HRRR valid  : {last_valid:%Y-%m-%d %H:%M}  (t{last_cyc:02d}z f{last_fhr:02d})  "
+          f"(want >= {want_last:%Y-%m-%d %H:%M})  -> {OK if cov_ok else BAD}")
+    print(f"  t0 fix  (#29)     : {OK if t0_ok else BAD}")
+    print(f"  full coverage     : {OK if cov_ok else BAD}")
+    return t0_ok and cov_ok
+
+
+# --------------------------------------------------------------------------
+# CHECK 2: datm_forcing.nc (numpy + netCDF4)
+# --------------------------------------------------------------------------
+def check_datm(path, cyc, pdy, nowcast_hours, forecast_hours):
+    import numpy as np
+    from netCDF4 import Dataset, num2date
+
+    cycle = dt.datetime.strptime(pdy, "%Y%m%d") + dt.timedelta(hours=cyc)
+    model_t0 = cycle - dt.timedelta(hours=nowcast_hours)
+
+    ds = Dataset(path)
+    uname = "UGRD_10maboveground" if "UGRD_10maboveground" in ds.variables else "uwind"
+    vname = "VGRD_10maboveground" if "VGRD_10maboveground" in ds.variables else "vwind"
+    tv = ds.variables["time"]
+    times = list(num2date(tv[:], tv.units, only_use_cftime_datetimes=False,
+                          only_use_python_datetimes=True))
+    if "data_source" in ds.variables:
+        src = np.asarray(ds.variables["data_source"][:]) == 1   # HRRR cells
+    else:
+        src = None
+
+    print("=" * 70)
+    print(f"CHECK 2  DATM  {path.split('/')[-1]}")
+    print("=" * 70)
+    print(f"  steps {len(times)} : {times[0]:%Y-%m-%d %H:%M} .. {times[-1]:%Y-%m-%d %H:%M}")
+    print(f"  {'lead':>5}  {'time':<16} {'sharp':>7}  source")
+    hrrr_leads = []
+    U, V = ds.variables[uname], ds.variables[vname]
+    for i, t in enumerate(times):
+        u = np.asarray(U[i], dtype="f8"); v = np.asarray(V[i], dtype="f8")
+        ws = np.hypot(u, v)
+        gy, gx = np.gradient(ws)
+        g = np.hypot(gy, gx)
+        sharp = float(np.nanmean(g[src])) if src is not None else float(np.nanmean(g))
+        lead = (t - cycle).total_seconds() / 3600
+        is_hrrr = sharp > SHARP_THRESH
+        if is_hrrr:
+            hrrr_leads.append(lead)
+        if i < 2 or i % 6 == 0 or i == len(times) - 1:
+            print(f"  {lead:+5.0f}  {t:%m-%d %H:%M}    {sharp:.4f}  {'HRRR' if is_hrrr else 'GFS'}")
+    ds.close()
+
+    t0_ok = bool(hrrr_leads) and min(hrrr_leads) <= (model_t0 - cycle).total_seconds() / 3600 + 0.01
+    cov_ok = bool(hrrr_leads) and max(hrrr_leads) >= forecast_hours - 0.01
+    print(f"  HRRR coverage     : lead {min(hrrr_leads):+.0f}h .. {max(hrrr_leads):+.0f}h "
+          f"({len(hrrr_leads)} steps)" if hrrr_leads else "  no HRRR steps")
+    print(f"  t0 (model_t0) HRRR: {OK if t0_ok else BAD}")
+    print(f"  reaches +{forecast_hours}h : {OK if cov_ok else BAD}")
+    return t0_ok and cov_ok
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Validate a SECOFS-UFS DATM run on WCOSS2.")
+    ap.add_argument("--manifest", help="path to *.inputs.prep.json")
+    ap.add_argument("--datm", help="path to datm_forcing.nc")
+    ap.add_argument("--cyc", type=int, help="cycle hour (read from manifest if omitted)")
+    ap.add_argument("--pdy", help="YYYYMMDD (read from manifest if omitted)")
+    ap.add_argument("--nowcast-hours", type=int, default=6)
+    ap.add_argument("--forecast-hours", type=int, default=48)
+    a = ap.parse_args()
+    if not a.manifest and not a.datm:
+        ap.error("give --manifest and/or --datm")
+
+    results = []
+    if a.manifest:
+        results.append(check_manifest(a.manifest, a.nowcast_hours, a.forecast_hours))
+        if (a.cyc is None or a.pdy is None):
+            man = json.load(open(a.manifest))
+            a.cyc = a.cyc if a.cyc is not None else int(man["cyc"])
+            a.pdy = a.pdy or man["pdy"]
+
+    if a.datm:
+        if a.cyc is None or a.pdy is None:
+            ap.error("--datm needs --cyc and --pdy (or pass --manifest too)")
+        try:
+            import numpy, netCDF4  # noqa: F401
+        except ImportError as e:
+            print(f"\n[skip CHECK 2] numpy/netCDF4 not importable: {e}")
+            print("  -> run with the prep python:  module load python/3.8.6")
+            print("     export PYTHONPATH=$HOMEnos/ush/python:$PYTHONPATH")
+        else:
+            results.append(check_datm(a.datm, a.cyc, a.pdy, a.nowcast_hours, a.forecast_hours))
+
+    print("=" * 70)
+    print("OVERALL:", OK if results and all(results) else BAD)
+    sys.exit(0 if results and all(results) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/SECOFS-UFS-DATM-VALIDATION/verify_hrrr_coverage.py
+++ b/SECOFS-UFS-DATM-VALIDATION/verify_hrrr_coverage.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""
+Verify HRRR forecast coverage in a prep input manifest.
+
+After delaying the prep cron so HRRR's later forecast hours have posted,
+run this on the new run's *.inputs.prep.json to confirm the fix:
+  - prep ran later relative to cycle (offset should grow ~+1.65h -> ~+2.5h)
+  - HRRR file count jumps (~34 -> ~54) and last forecast hour reaches f48
+
+Usage:
+  python3 verify_hrrr_coverage.py <prep_manifest.json> [more.json ...]
+  python3 verify_hrrr_coverage.py            # defaults to V19 t00/06/12/18z
+"""
+import glob
+import json
+import re
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+
+FORECAST_HOURS = 48   # secofs_ufs.yaml
+NOWCAST_HOURS = 6
+
+
+def hrrr_fhr_cycle(path):
+    m = re.search(r"hrrr\.(\d{8})/.*?hrrr\.t(\d{2})z\.wrfsfcf(\d{2,3})", path)
+    if not m:
+        return None
+    return m.group(1), m.group(2), int(m.group(3))
+
+
+def check(manifest_path):
+    m = json.load(open(manifest_path))
+    cyc = int(m["cyc"])
+    cycdt = (datetime.strptime(m["pdy"], "%Y%m%d").replace(tzinfo=timezone.utc)
+             + timedelta(hours=cyc))
+    gen = datetime.fromisoformat(m["generated_at"])
+    prep_off = (gen - cycdt).total_seconds() / 3600.0
+
+    hrrr = [e for e in m["inputs"] if (e.get("source") or "").upper() == "HRRR"]
+    files = hrrr[0]["files"] if hrrr else []
+    bycyc = defaultdict(list)
+    for f in files:
+        r = hrrr_fhr_cycle(f)
+        if r:
+            bycyc[(r[0], r[1])].append(r[2])
+    # main forecast cycle = the one contributing the most forecast hours
+    last_fhr = 0
+    fcst_cycle = "--"
+    if bycyc:
+        main = max(bycyc.items(), key=lambda kv: len(kv[1]))
+        fcst_cycle, last_fhr = f"t{main[0][1]}z", max(main[1])
+
+    expected = NOWCAST_HOURS + FORECAST_HOURS          # ~54
+    gap = FORECAST_HOURS - last_fhr                     # forecast hours on GFS fallback
+    status = "OK   " if last_fhr >= FORECAST_HOURS else "SHORT"
+    print(f"{m['pdy']} t{cyc:02d}z | prep +{prep_off:4.2f}h | "
+          f"HRRR files {len(files):2d}/{expected} | fcst {fcst_cycle} f01..{last_fhr:02d} | "
+          f"last-{gap}h on GFS | {status}")
+    return last_fhr >= FORECAST_HOURS
+
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    if not args:
+        args = sorted(glob.glob(
+            "/mnt/e/secofs_com_outs/PYTHON_V14/V19/"
+            "secofs_ufs.t*z.20260604.inputs.prep.json"))
+    print("cycle        | prep offset | HRRR coverage | forecast HRRR     | fallback | verdict")
+    print("-" * 92)
+    results = [check(a) for a in args]   # evaluate every cycle (no short-circuit)
+    all_ok = all(results)
+    print("-" * 92)
+    print("ALL CYCLES REACH f48" if all_ok else
+          "still SHORT -> prep is still running before HRRR f48 posts (delay cron further)")


### PR DESCRIPTION
…TM compare tools

- validate_datm_wcoss2.py : WCOSS2 validator. Manifest check = stdlib only; DATM check = numpy+netCDF4. Confirms the UFS DATM blend uses HRRR at model_t0 and HRRR coverage reaches +forecast_hours. PASS/FAIL.
- plot_windspeed_sequence_hrrr_ufs.py : 3-panel SCHISM-sflux vs UFS-DATM wind-speed frames (CLI args: --datm/--sflux-src/--cyc/--pdy/--nest/--out; --nest 1=GFS, 2=HRRR; Agg backend; HRRR/GFS boundary overlay; forecast-phase sflux dedup).
- verify_hrrr_coverage.py : prep-manifest HRRR coverage check (stdlib only).
- analyze_hrrr_posting.py : HRRR file posting-time -> recommended prep cron offset.