### PR TITLE
Add OBC/tides parity + comparison plot tools

### DIFF
--- a/SECOFS-UFS-DATM-VALIDATION/plot_bctides_compare.py
+++ b/SECOFS-UFS-DATM-VALIDATION/plot_bctides_compare.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""
+Plot bctides.in: nodal factors / equilibrium args + ocean-boundary harmonics,
+operational (secofs) vs UFS (secofs_ufs). Parses the file (no hardcoded values).
+
+Usage:
+  python3 plot_bctides_compare.py OPS_bctides.in UFS_bctides.in [--out out.png] [--label "..."]
+"""
+import argparse
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+CONS = ["M2", "S2", "N2", "K2", "K1", "O1", "P1", "Q1"]
+
+
+def parse_bctides(path):
+    L = open(path).read().splitlines()
+    i = 0
+    date = L[i].strip(); i += 1
+    ntip = int(L[i].split()[0]); i += 1
+    pot = {}                       # name -> (nodal_f, eq_arg)
+    for _ in range(ntip):
+        name = L[i].split()[0].upper(); i += 1
+        d = L[i].split(); i += 1
+        pot[name] = (float(d[3]), float(d[4]))
+    nbfr = int(L[i].split()[0]); i += 1
+    bfr_names = []
+    for _ in range(nbfr):
+        name = L[i].split()[0].upper(); i += 1
+        i += 1                     # skip the "freq f eqarg" line
+        bfr_names.append(name)
+    int(L[i].split()[0]); i += 1   # nope
+    hdr = L[i].split(); i += 1     # first boundary header: nnodes iettype ifltype ...
+    nnodes, iettype = int(hdr[0]), int(hdr[1])
+    elev = {}                      # name -> (amp[], phase[])
+    if iettype in (3, 5):
+        for _ in range(nbfr):
+            cname = L[i].split()[0].upper(); i += 1
+            amp, ph = [], []
+            for _ in range(nnodes):
+                p = L[i].split(); i += 1
+                amp.append(float(p[0])); ph.append(float(p[1]))
+            elev[cname] = (np.array(amp), np.array(ph))
+    return {"date": date, "pot": pot, "nnodes": nnodes, "elev": elev}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("ops"); ap.add_argument("ufs")
+    ap.add_argument("--out", default="bctides_compare.png")
+    ap.add_argument("--label", default="operational (secofs) vs UFS (secofs_ufs)")
+    a = ap.parse_args()
+    O, U = parse_bctides(a.ops), parse_bctides(a.ufs)
+
+    cons = [c for c in CONS if c in O["pot"]]
+    x = np.arange(len(cons)); w = 0.38
+    of = [O["pot"][c][0] for c in cons]; uf = [U["pot"][c][0] for c in cons]
+    ov = [O["pot"][c][1] for c in cons]; uv = [U["pot"][c][1] for c in cons]
+
+    fig, ax = plt.subplots(2, 2, figsize=(18, 11), constrained_layout=True)
+
+    ax[0, 0].bar(x - w/2, of, w, color="#2166ac", label="operational", edgecolor="white")
+    ax[0, 0].bar(x + w/2, uf, w, color="#1a9850", label="UFS", edgecolor="white")
+    ax[0, 0].set_xticks(x); ax[0, 0].set_xticklabels(cons, fontweight="bold")
+    ax[0, 0].set_title(f"Nodal factors (f)   max|diff|={max(abs(a-b) for a,b in zip(of,uf)):.1e}")
+    ax[0, 0].set_ylabel("f"); ax[0, 0].axhline(1, color="k", ls="--", lw=0.7, alpha=0.4)
+    ax[0, 0].legend(); ax[0, 0].grid(True, axis="y", alpha=0.2)
+
+    ax[0, 1].bar(x - w/2, ov, w, color="#2166ac", label="operational", edgecolor="white")
+    ax[0, 1].bar(x + w/2, uv, w, color="#1a9850", label="UFS", edgecolor="white")
+    ax[0, 1].set_xticks(x); ax[0, 1].set_xticklabels(cons, fontweight="bold")
+    ax[0, 1].set_title(f"Equilibrium args (V0+u, deg)   max|diff|={max(abs(a-b) for a,b in zip(ov,uv)):.1e}")
+    ax[0, 1].set_ylabel("deg"); ax[0, 1].legend(); ax[0, 1].grid(True, axis="y", alpha=0.2)
+
+    show = [c for c in ("M2", "S2", "K1", "O1") if c in O["elev"]]
+    colors = {"M2": "#d73027", "S2": "#fc8d59", "K1": "#4575b4", "O1": "#91bfdb"}
+    if show:
+        n = O["nnodes"]; xn = np.arange(n)
+        for c in show:
+            ax[1, 0].plot(xn, O["elev"][c][0], color=colors[c], lw=1.4, label=f"{c} ops")
+            ax[1, 0].plot(xn, U["elev"][c][0], color="k", lw=0.8, ls="--", alpha=0.7)
+        ax[1, 0].set_title(f"Ocean-boundary elevation AMPLITUDE per node ({n} nodes)\n"
+                           "ops=color, ufs=black dashed")
+        ax[1, 0].set_xlabel("boundary node index"); ax[1, 0].set_ylabel("amplitude (m)")
+        ax[1, 0].legend(fontsize=9, ncol=2); ax[1, 0].grid(True, alpha=0.2)
+
+        for c in ("M2", "K1"):
+            if c in O["elev"]:
+                ax[1, 1].plot(xn, O["elev"][c][1], color=colors[c], lw=1.4, label=f"{c} ops")
+                ax[1, 1].plot(xn, U["elev"][c][1], color="k", lw=0.8, ls="--", alpha=0.7)
+        # max amp diff across shown constituents
+        md = max(float(np.max(np.abs(O["elev"][c][0] - U["elev"][c][0]))) for c in show)
+        ax[1, 1].set_title(f"Ocean-boundary PHASE per node (M2, K1)   max|amp diff|={md:.1e} m")
+        ax[1, 1].set_xlabel("boundary node index"); ax[1, 1].set_ylabel("phase (deg)")
+        ax[1, 1].legend(fontsize=9); ax[1, 1].grid(True, alpha=0.2)
+
+    fig.suptitle(f"bctides.in  -  {a.label}\nops date: {O['date']}   |   ufs date: {U['date']}",
+                 fontsize=14, fontweight="bold")
+    fig.savefig(a.out, dpi=130, bbox_inches="tight")
+    print("saved", a.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/SECOFS-UFS-DATM-VALIDATION/plot_obc_ssh_boundary_map.py
+++ b/SECOFS-UFS-DATM-VALIDATION/plot_obc_ssh_boundary_map.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""
+OBC elev2D (SSH) BOUNDARY MAP: operational vs UFS vs diff, at several time
+snapshots (reference-plot style 04_ssh_boundary_map.png).
+
+elev2D.th.nc has no coordinates, so the open-boundary node lon/lat are pulled
+from the SECOFS hgrid.gr3 (open boundaries 1..NBND, which for SECOFS = the
+1488 elevation-forced nodes). Coords are cached to a small .npz so the 321 MB
+hgrid is parsed only once.
+
+Usage:
+  python3 plot_obc_ssh_boundary_map.py OPS_elev2D.th.nc UFS_elev2D.th.nc \
+      --hgrid /path/to/hgrid.gr3 [--nbnd 3] [--out map.png] [--snaps 0,8,16]
+"""
+import argparse
+import os
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+from netCDF4 import Dataset
+
+
+def boundary_coords(hgrid, nbnd, cache):
+    if cache and os.path.exists(cache):
+        z = np.load(cache); return z["lon"], z["lat"]
+    with open(hgrid) as f:
+        f.readline()
+        ne, nn = (int(x) for x in f.readline().split()[:2])
+        lon = np.empty(nn); lat = np.empty(nn)
+        for i in range(nn):
+            p = f.readline().split(); lon[i] = float(p[1]); lat[i] = float(p[2])
+        for _ in range(ne):
+            f.readline()
+        n_open = int(f.readline().split()[0]); f.readline()  # n_open ; total
+        ids = []
+        for b in range(n_open):
+            cnt = int(f.readline().split()[0])
+            bids = [int(f.readline().split()[0]) for _ in range(cnt)]
+            if b < nbnd:
+                ids.extend(bids)
+    idx = np.array(ids) - 1
+    blon, blat = lon[idx], lat[idx]
+    if cache:
+        np.savez(cache, lon=blon, lat=blat)
+    return blon, blat
+
+
+def load_ssh(path):
+    ds = Dataset(path)
+    ts = np.array(ds.variables["time_series"][:, :, 0, 0], dtype="f8")
+    ds.close(); return ts
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("ops"); ap.add_argument("ufs")
+    ap.add_argument("--hgrid", required=True)
+    ap.add_argument("--nbnd", type=int, default=3, help="num open boundaries = elev2D nodes")
+    ap.add_argument("--cache", default="secofs_obc_bnd_coords.npz")
+    ap.add_argument("--snaps", default=None, help="comma time-indices (default 3 evenly spaced)")
+    ap.add_argument("--out", default="obc_ssh_boundary_map.png")
+    ap.add_argument("--label", default="operational vs UFS")
+    a = ap.parse_args()
+
+    lon, lat = boundary_coords(a.hgrid, a.nbnd, a.cache)
+    so, su = load_ssh(a.ops), load_ssh(a.ufs)
+    nt = min(so.shape[0], su.shape[0]); nn = min(so.shape[1], su.shape[1], len(lon))
+    so, su, lon, lat = so[:nt, :nn], su[:nt, :nn], lon[:nn], lat[:nn]
+    print(f"nodes={nn}  steps={nt}  lon[{lon.min():.1f},{lon.max():.1f}] lat[{lat.min():.1f},{lat.max():.1f}]")
+
+    snaps = ([int(x) for x in a.snaps.split(",")] if a.snaps
+             else [0, nt // 2, nt - 1])
+    vmax = max(np.nanmax(np.abs(so)), np.nanmax(np.abs(su)))
+    dmax = max(np.nanmax(np.abs(su - so)), 1e-4)
+
+    fig, ax = plt.subplots(len(snaps), 3, figsize=(15, 4.4 * len(snaps)), constrained_layout=True)
+    if len(snaps) == 1:
+        ax = ax[None, :]
+    for r, ti in enumerate(snaps):
+        for c, (dat, ttl, cmap, vlo, vhi) in enumerate([
+                (so[ti], "operational", "RdBu_r", -vmax, vmax),
+                (su[ti], "UFS", "RdBu_r", -vmax, vmax),
+                (su[ti] - so[ti], "diff (UFS-ops)", "bwr", -dmax, dmax)]):
+            sc = ax[r, c].scatter(lon, lat, c=dat, s=6, cmap=cmap, vmin=vlo, vmax=vhi)
+            plt.colorbar(sc, ax=ax[r, c], fraction=0.046, pad=0.04,
+                         label="SSH (m)" if c < 2 else "m")
+            rm = np.sqrt(np.nanmean((su[ti] - so[ti]) ** 2)) * 1000
+            ax[r, c].set_title(f"{ttl}" + (f"  step {ti}" if c == 0 else
+                               (f"  RMSE={rm:.3f}mm" if c == 2 else "")), fontsize=10)
+            ax[r, c].set_xlabel("lon"); ax[r, c].set_ylabel("lat")
+            ax[r, c].set_aspect("auto")
+    fig.suptitle(f"SSH at open-boundary nodes ({nn}): {a.label}", fontsize=14, fontweight="bold")
+    fig.savefig(a.out, dpi=130, bbox_inches="tight")
+    print("saved", a.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/SECOFS-UFS-DATM-VALIDATION/plot_obc_ssh_compare.py
+++ b/SECOFS-UFS-DATM-VALIDATION/plot_obc_ssh_compare.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""
+OBC elev2D (SSH) time-series comparison at a few boundary nodes:
+operational (secofs) vs UFS (secofs_ufs), reference-plot style (2x2 nodes).
+
+Inputs are the two elev2D.th.nc files (extract them from obc.tar first, e.g.
+  tar -xf <obc.tar> elev2D.th.nc).
+
+Usage:
+  python3 plot_obc_ssh_compare.py OPS_elev2D.th.nc UFS_elev2D.th.nc \
+      [--out ssh.png] [--nodes 0,500,1000,1400] [--label "..."]
+"""
+import argparse
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+from netCDF4 import Dataset
+
+
+def load(path):
+    ds = Dataset(path)
+    t = np.array(ds.variables["time"][:], dtype="f8")
+    ts = np.array(ds.variables["time_series"][:, :, 0, 0], dtype="f8")  # (time, node)
+    ds.close()
+    return t, ts
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("ops"); ap.add_argument("ufs")
+    ap.add_argument("--out", default="obc_ssh_compare.png")
+    ap.add_argument("--nodes", default="0,500,1000,1400")
+    ap.add_argument("--maxlag", type=int, default=400, help="max alignment lag in steps")
+    ap.add_argument("--label", default="operational (secofs) vs UFS (secofs_ufs)")
+    a = ap.parse_args()
+
+    to, so = load(a.ops); tu, su = load(a.ufs)
+    nn = min(so.shape[1], su.shape[1])
+    so, su = so[:, :nn], su[:, :nn]
+    dt = (to[1] - to[0]) if len(to) > 1 else 120.0
+
+    # The two OBC windows can differ in nowcast lookback and there is no
+    # base_date in the file, so AUTO-ALIGN: find the integer step lag that
+    # minimizes RMSE (search a subset of nodes for speed), then trim to overlap.
+    sub = slice(0, nn, max(1, nn // 40))
+    best = (0, np.inf)
+    for lag in range(-a.maxlag, a.maxlag + 1):
+        if lag >= 0:
+            A = so[lag:, sub]; B = su[:A.shape[0], sub]
+        else:
+            A = so[:, sub]; B = su[-lag:, sub]; A = A[:B.shape[0]]
+        n = min(A.shape[0], B.shape[0])
+        if n < 300:
+            continue
+        rr = np.sqrt(np.nanmean((A[:n] - B[:n]) ** 2))
+        if rr < best[1]:
+            best = (lag, rr)
+    lag = best[0]
+    offset_h = lag * dt / 3600.0
+    if lag >= 0:
+        so, su = so[lag:], su[:so.shape[0] - lag]
+    else:
+        so, su = so[:su.shape[0] + lag], su[-lag:]
+    nt = min(so.shape[0], su.shape[0])
+    so, su = so[:nt], su[:nt]
+    ho = hu = np.arange(nt) * dt / 3600.0   # hours into the aligned overlap
+    nodes = [int(x) for x in a.nodes.split(",") if int(x) < nn]
+
+    # overall stats over the common window
+    diff = su - so
+    rmse_mm = float(np.sqrt(np.nanmean(diff ** 2))) * 1000.0
+    maxmm = float(np.nanmax(np.abs(diff))) * 1000.0
+    r = np.corrcoef(so.ravel(), su.ravel())[0, 1]
+
+    fig, axes = plt.subplots(2, 2, figsize=(16, 9), constrained_layout=True)
+    for ax, nd in zip(axes.ravel(), nodes):
+        ax.plot(ho, so[:, nd], color="blue", lw=1.6, label="operational (secofs)")
+        ax.plot(hu, su[:, nd], color="red", lw=1.2, ls="--", label="UFS (secofs_ufs)")
+        ax.set_title(f"Node {nd}")
+        ax.set_xlabel("Time (hours)"); ax.set_ylabel("SSH (m)")
+        ax.grid(True, alpha=0.25); ax.legend(fontsize=9)
+
+    fig.suptitle(f"OBC elev2D (SSH): {a.label}\n"
+                 f"aligned (ops leads ufs by {offset_h:+.1f}h), {nt} steps x {nn} nodes   "
+                 f"RMSE={rmse_mm:.3f}mm  max|diff|={maxmm:.3f}mm  R={r:.6f}",
+                 fontsize=14, fontweight="bold")
+    fig.savefig(a.out, dpi=130, bbox_inches="tight")
+    print(f"saved {a.out}  (RMSE={rmse_mm:.3f}mm, max={maxmm:.3f}mm, R={r:.6f})")
+
+
+if __name__ == "__main__":
+    main()

--- a/SECOFS-UFS-DATM-VALIDATION/validate_prep_parity_wcoss2.py
+++ b/SECOFS-UFS-DATM-VALIDATION/validate_prep_parity_wcoss2.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""
+Validate prep PARITY between two COMOUTs (operational/standalone vs UFS
+secofs_ufs) for the non-atmospheric products: OBC, River, Tides.
+
+Most of these SHOULD be identical between the two paths (same RTOFS/NWM/tidal
+inputs regardless of nws=2 vs nws=4). Known intentional differences: the UFS
+OBC node subset (e.g. 781 -> 778) and elev2D model_dt. This tool reports
+MATCH / DIFF per product, with where, so unexpected drift is caught and the
+expected diffs are visible (it still compares values at the common nodes).
+
+Library-graceful for WCOSS2:
+  - River, Tides : Python standard library only.
+  - OBC (.th.nc) : numpy + netCDF4 (present in the prep env).
+
+Files are matched by SUFFIX inside each dir, so you just pass the two COMOUTs:
+  module load python/3.8.6
+  python3 validate_prep_parity_wcoss2.py \
+      --ops-dir /path/to/standalone/COMOUT \
+      --ufs-dir /path/to/secofs_ufs/COMOUT \
+      --phase nowcast --products obc,river,tides
+"""
+import argparse
+import glob
+import os
+import shutil
+import sys
+import tarfile
+import tempfile
+
+TOL = 1e-4   # max abs difference treated as "MATCH"
+OBC_TIME_SAMPLES = 50   # evenly-spaced timesteps sampled per .th.nc (memory-safe)
+
+
+def find_suffix(d, suffix):
+    hits = sorted(glob.glob(os.path.join(d, "*" + suffix)))
+    return hits[0] if hits else None
+
+
+# ----------------------------- River (.th ASCII) ---------------------------
+def _read_th(path):
+    rows = []
+    with open(path) as f:
+        for ln in f:
+            p = ln.split()
+            if p:
+                rows.append([float(x) for x in p])
+    return rows
+
+
+def compare_river(ops, ufs):
+    print("=" * 70); print("RIVER (NWM)"); print("=" * 70)
+    ok = True
+    seen = False
+    for kind in ("vsource", "vsink", "msource"):
+        a = find_suffix(ops, f".river.{kind}.th")
+        b = find_suffix(ufs, f".river.{kind}.th")
+        if not a or not b:
+            if a or b:
+                print(f"  {kind:8s}: SKIP  (ops={'y' if a else 'n'} ufs={'y' if b else 'n'})")
+            continue
+        seen = True
+        ra, rb = _read_th(a), _read_th(b)
+        na, nca = len(ra), (len(ra[0]) if ra else 0)
+        nb, ncb = len(rb), (len(rb[0]) if rb else 0)
+        if (na, nca) != (nb, ncb):
+            print(f"  {kind:8s}: DIFF shape  ops={na}x{nca}  ufs={nb}x{ncb}"); ok = False; continue
+        md = 0.0
+        for r1, r2 in zip(ra, rb):
+            for x, y in zip(r1, r2):
+                d = abs(x - y)
+                if d > md:
+                    md = d
+        v = "MATCH" if md <= TOL else "DIFF"
+        ok = ok and md <= TOL
+        print(f"  {kind:8s}: {v}  ({na} rows x {nca} cols, max|diff|={md:.3e})")
+    return ok if seen else None
+
+
+# ----------------------------- Tides (bctides.in) --------------------------
+def _norm(path):
+    return [ln.rstrip() for ln in open(path).read().splitlines()]
+
+
+def compare_tides(ops, ufs, phase):
+    print("=" * 70); print("TIDES (bctides.in)"); print("=" * 70)
+    a = find_suffix(ops, f".bctides.in.{phase}") or find_suffix(ops, ".bctides.in")
+    b = find_suffix(ufs, f".bctides.in.{phase}") or find_suffix(ufs, ".bctides.in")
+    if not a or not b:
+        print(f"  SKIP  (ops={'y' if a else 'n'} ufs={'y' if b else 'n'})"); return None
+    la, lb = _norm(a), _norm(b)
+    if la == lb:
+        print(f"  bctides.in: MATCH  ({len(la)} lines identical)"); return True
+    ndiff = sum(1 for x, y in zip(la, lb) if x != y) + abs(len(la) - len(lb))
+    print(f"  bctides.in: DIFF  ({ndiff} differing lines; {len(la)} vs {len(lb)} lines)")
+    shown = 0
+    for i, (x, y) in enumerate(zip(la, lb)):
+        if x != y and shown < 6:
+            print(f"    L{i+1:4d} ops: {x[:60]}")
+            print(f"         ufs: {y[:60]}")
+            shown += 1
+    return False
+
+
+# ----------------------------- OBC (.th.nc) --------------------------------
+def compare_obc(ops, ufs, phase):
+    print("=" * 70); print("OBC (RTOFS)"); print("=" * 70)
+    try:
+        import numpy as np
+        from netCDF4 import Dataset
+    except ImportError as e:
+        print(f"  SKIP: numpy/netCDF4 not importable ({e})")
+        print("    -> module load python/3.8.6 ; export PYTHONPATH=$HOMEnos/ush/python:$PYTHONPATH")
+        return None
+    a = find_suffix(ops, f".obc.{phase}.tar") or find_suffix(ops, ".obc.tar")
+    b = find_suffix(ufs, f".obc.{phase}.tar") or find_suffix(ufs, ".obc.tar")
+    if not a or not b:
+        print(f"  SKIP  (ops={'y' if a else 'n'} ufs={'y' if b else 'n'})"); return None
+    da, db = tempfile.mkdtemp(prefix="obc_a_"), tempfile.mkdtemp(prefix="obc_b_")
+    ok = True
+    try:
+        with tarfile.open(a) as t:
+            t.extractall(da, filter="data")
+        with tarfile.open(b) as t:
+            t.extractall(db, filter="data")
+        for fn in ("elev2D.th.nc", "TEM_3D.th.nc", "SAL_3D.th.nc", "uv3D.th.nc"):
+            fa = find_suffix(da, fn) or (glob.glob(os.path.join(da, "**", fn), recursive=True) or [None])[0]
+            fb = find_suffix(db, fn) or (glob.glob(os.path.join(db, "**", fn), recursive=True) or [None])[0]
+            if not fa or not fb:
+                continue
+            dsa, dsb = Dataset(fa), Dataset(fb)
+            va, vb = dsa.variables["time_series"], dsb.variables["time_series"]
+            sa, sb = tuple(va.shape), tuple(vb.shape)
+            nt = min(sa[0], sb[0]); nn = min(sa[1], sb[1])
+            idx = range(0, nt, max(1, nt // OBC_TIME_SAMPLES))
+            md = 0.0; sse = 0.0; cnt = 0
+            for i in idx:
+                xa = np.asarray(va[i, :nn], dtype="f8")
+                xb = np.asarray(vb[i, :nn], dtype="f8")
+                d = np.abs(xa - xb)
+                md = max(md, float(np.nanmax(d)))
+                sse += float(np.nansum(d ** 2)); cnt += d.size
+            rmse = (sse / cnt) ** 0.5 if cnt else float("nan")
+            shape_note = "" if sa == sb else f"  SHAPE ops={sa} ufs={sb} (node/level diff)"
+            val = "MATCH" if md <= TOL else "DIFF"
+            ok = ok and (md <= TOL) and (sa == sb)
+            print(f"  {fn:13s}: {val}{shape_note}")
+            print(f"               common[{nt}x{nn}] sampled {len(list(idx))} steps: "
+                  f"max|diff|={md:.3e} rmse={rmse:.3e}")
+            dsa.close(); dsb.close()
+    finally:
+        shutil.rmtree(da, ignore_errors=True)
+        shutil.rmtree(db, ignore_errors=True)
+    return ok
+
+
+def main():
+    global TOL
+    ap = argparse.ArgumentParser(description="Validate OBC/River/Tides parity between two COMOUTs.")
+    ap.add_argument("--ops-dir", required=True, help="operational/standalone COMOUT")
+    ap.add_argument("--ufs-dir", required=True, help="secofs_ufs COMOUT")
+    ap.add_argument("--phase", default="nowcast", choices=("nowcast", "forecast"))
+    ap.add_argument("--products", default="obc,river,tides",
+                    help="comma list of obc,river,tides (default all)")
+    ap.add_argument("--tol", type=float, default=TOL)
+    a = ap.parse_args()
+    TOL = a.tol
+    want = {p.strip() for p in a.products.split(",")}
+
+    print(f"ops : {a.ops_dir}")
+    print(f"ufs : {a.ufs_dir}")
+    print(f"phase={a.phase}  products={sorted(want)}  tol={TOL:g}\n")
+
+    results = {}
+    if "obc" in want:
+        results["OBC"] = compare_obc(a.ops_dir, a.ufs_dir, a.phase)
+    if "river" in want:
+        results["RIVER"] = compare_river(a.ops_dir, a.ufs_dir)
+    if "tides" in want:
+        results["TIDES"] = compare_tides(a.ops_dir, a.ufs_dir, a.phase)
+
+    print("=" * 70)
+    for k, v in results.items():
+        print(f"  {k:6s}: {'MATCH' if v else ('SKIP' if v is None else 'DIFF')}")
+    hard = [v for v in results.values() if v is not None]
+    print("OVERALL:", "MATCH" if hard and all(hard) else ("SKIP" if not hard else "DIFF"))
+    sys.exit(0 if (hard and all(hard)) else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds the OBC/tides validation tools to SECOFS-UFS-DATM-VALIDATION/ (completes the suite alongside the DATM tools from #3):

- validate_prep_parity_wcoss2.py - OBC/River/Tides MATCH/DIFF between two COMOUTs
- plot_bctides_compare.py - bctides nodal factors + ocean-boundary harmonics
- plot_obc_ssh_compare.py - elev2D SSH timeseries at nodes (auto-aligns window offset)
- plot_obc_ssh_boundary_map.py - elev2D SSH spatial boundary map (lon/lat from hgrid)

All CLI-driven, library-graceful (stdlib where possible), memory-frugal.