### PR TITLE
Add NWM river forcing validation scripts (operational vs UFS)

### DIFF
--- a/SECOFS-UFS-DATM-VALIDATION/plot_discharge_extra.py
+++ b/SECOFS-UFS-DATM-VALIDATION/plot_discharge_extra.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Extra NWM discharge comparisons (operational vs UFS) from vsource.th.
+
+Companion to plot_nwm_vsource_compare.py. vsource.th layout: col0 = time(s),
+cols1..N = per-source volume discharge (m3/s).
+
+Fig 1 (<prefix>_top16_hydrographs.png): per-source hydrographs for the top-N
+       sources (ops vs ufs, per-panel RMSE / correlation).
+Fig 2 (<prefix>_summary_panels.png): total-discharge overlay + residual,
+       cumulative delivered volume, and the per-source RMSE distribution (ECDF).
+
+Auto-aligns any nowcast-window offset (cross-correlation on active sources).
+
+Usage:
+  python3 plot_discharge_extra.py OPS_vsource.th UFS_vsource.th \
+      [--source-sink source_sink.in] [--out-prefix discharge] \
+      [--label "..."] [--topn 16] [--maxlag 12]
+"""
+import argparse
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+ACTIVE = 0.011   # > this (m3/s) counts as an active source (0.01 is the placeholder)
+
+
+def align(O, U, maxlag):
+    """Cross-correlation align on active sources; return trimmed (qo, qu, dt, off_h)."""
+    qo, qu = O[:, 1:], U[:, 1:]
+    ns = min(qo.shape[1], qu.shape[1]); qo, qu = qo[:, :ns], qu[:, :ns]
+    dt = (O[1, 0] - O[0, 0]) if len(O) > 1 else 3600.0
+    act = qo.max(0) > ACTIVE
+    best = (0, np.inf)
+    for lag in range(-maxlag, maxlag + 1):
+        if lag >= 0:
+            A = qo[lag:][:, act]; B = qu[:A.shape[0]][:, act]
+        else:
+            A = qo[:qu.shape[0] + lag][:, act]; B = qu[-lag:][:, act]
+        n = min(A.shape[0], B.shape[0])
+        if n < 5:
+            continue
+        rr = np.sqrt(np.nanmean((A[:n] - B[:n]) ** 2))
+        if rr < best[1]:
+            best = (lag, rr)
+    lag = best[0]
+    if lag >= 0:
+        qo, qu = qo[lag:], qu[:qo.shape[0] - lag]
+    else:
+        qo, qu = qo[:qu.shape[0] + lag], qu[-lag:]
+    nt = min(qo.shape[0], qu.shape[0])
+    return qo[:nt], qu[:nt], dt, lag * dt / 3600.0
+
+
+def elem_ids(path, n):
+    """Read source element ids from source_sink.in (else fall back to indices)."""
+    if not path:
+        return list(range(n))
+    try:
+        with open(path) as f:
+            lines = [ln.strip() for ln in f if ln.strip()]
+        nsrc = int(lines[0])
+        return [int(lines[1 + i]) for i in range(min(nsrc, n))]
+    except Exception:
+        return list(range(n))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("ops"); ap.add_argument("ufs")
+    ap.add_argument("--source-sink", default=None, help="source_sink.in for element-id labels")
+    ap.add_argument("--out-prefix", default="discharge")
+    ap.add_argument("--label", default="operational vs UFS")
+    ap.add_argument("--topn", type=int, default=16)
+    ap.add_argument("--maxlag", type=int, default=12)
+    a = ap.parse_args()
+
+    O = np.loadtxt(a.ops); U = np.loadtxt(a.ufs)
+    qo, qu, dt, offh = align(O, U, a.maxlag)
+    nt, ns = qo.shape
+    hrs = np.arange(nt) * dt / 3600.0
+    eids = elem_ids(a.source_sink, ns)
+
+    # ---- Fig 1: top-N source hydrographs ----------------------------------
+    order = np.argsort(np.maximum(qo.mean(0), qu.mean(0)))[::-1]
+    top = order[:a.topn]
+    ncol = 4; nrow = int(np.ceil(len(top) / ncol))
+    fig, ax = plt.subplots(nrow, ncol, figsize=(4 * ncol, 2.7 * nrow),
+                           constrained_layout=True, squeeze=False)
+    for i, k in enumerate(top):
+        axk = ax.flat[i]
+        axk.plot(hrs, qo[:, k], color="blue", lw=1.6, label="ops")
+        axk.plot(hrs, qu[:, k], color="red", lw=1.1, ls="--", label="ufs")
+        rk = np.sqrt(np.nanmean((qu[:, k] - qo[:, k]) ** 2))
+        corr = np.corrcoef(qo[:, k], qu[:, k])[0, 1] if qo[:, k].std() > 0 else 1.0
+        eid = eids[k] if k < len(eids) else k
+        axk.set_title(f"src#{k} elem {eid}  RMSE={rk:.2g}  r={corr:.3f}", fontsize=9)
+        axk.grid(True, alpha=0.25); axk.tick_params(labelsize=8)
+        if i == 0:
+            axk.legend(fontsize=8)
+    for j in range(len(top), nrow * ncol):
+        ax.flat[j].axis("off")
+    fig.suptitle(f"Top-{len(top)} NWM source hydrographs: operational (blue) vs UFS (red dashed)\n"
+                 f"{a.label}, aligned {offh:+.1f}h, {nt} steps",
+                 fontsize=13, fontweight="bold")
+    fig.supxlabel("Time (hours)"); fig.supylabel("discharge (m3/s)")
+    fig.savefig(f"{a.out_prefix}_top16_hydrographs.png", dpi=95, bbox_inches="tight")
+    plt.close(fig)
+
+    # ---- Fig 2: total / residual / cumulative / error distribution --------
+    to, tu = qo.sum(1), qu.sum(1)
+    fig, ax = plt.subplots(2, 2, figsize=(14, 9), constrained_layout=True)
+
+    ax[0, 0].plot(hrs, to, color="blue", lw=1.8, label="operational")
+    ax[0, 0].plot(hrs, tu, color="red", lw=1.2, ls="--", label="UFS")
+    ax[0, 0].set_title("Total domain discharge"); ax[0, 0].set_ylabel("m3/s")
+    ax[0, 0].set_xlabel("Time (hours)"); ax[0, 0].grid(True, alpha=0.25); ax[0, 0].legend()
+
+    resid = tu - to
+    ax[0, 1].plot(hrs, resid, color="purple", lw=1.3)
+    ax[0, 1].axhline(0, color="k", lw=0.8)
+    ax[0, 1].fill_between(hrs, resid, 0, alpha=0.2, color="purple")
+    ax[0, 1].set_title(f"Total-discharge residual (UFS - ops)   "
+                       f"mean={resid.mean():+.1f}  RMS={np.sqrt((resid**2).mean()):.1f} m3/s")
+    ax[0, 1].set_ylabel("m3/s"); ax[0, 1].set_xlabel("Time (hours)"); ax[0, 1].grid(True, alpha=0.25)
+
+    vol_o = np.cumsum(to) * dt / 1e9   # km3
+    vol_u = np.cumsum(tu) * dt / 1e9
+    ax[1, 0].plot(hrs, vol_o, color="blue", lw=1.8, label="operational")
+    ax[1, 0].plot(hrs, vol_u, color="red", lw=1.2, ls="--", label="UFS")
+    pct = 100 * (vol_u[-1] - vol_o[-1]) / vol_o[-1] if vol_o[-1] else 0.0
+    ax[1, 0].set_title(f"Cumulative delivered volume   "
+                       f"final ops={vol_o[-1]:.3f} ufs={vol_u[-1]:.3f} km3 ({pct:+.2f}%)")
+    ax[1, 0].set_ylabel("km3"); ax[1, 0].set_xlabel("Time (hours)")
+    ax[1, 0].grid(True, alpha=0.25); ax[1, 0].legend()
+
+    per_rmse = np.sqrt(np.mean((qu - qo) ** 2, axis=0))
+    active = qo.max(0) > ACTIVE
+    pr = np.sort(per_rmse[active])
+    ecdf = np.arange(1, len(pr) + 1) / len(pr)
+    ax[1, 1].plot(pr, ecdf, lw=1.6)
+    med = np.median(pr); p95 = np.percentile(pr, 95)
+    ax[1, 1].axvline(med, color="g", ls="--", lw=0.9, label=f"median={med:.3g}")
+    ax[1, 1].axvline(p95, color="orange", ls="--", lw=0.9, label=f"95th={p95:.3g}")
+    ax[1, 1].set_xscale("log")
+    ax[1, 1].set_title(f"Per-source RMSE distribution (ECDF, {int(active.sum())} active sources)")
+    ax[1, 1].set_xlabel("per-source RMSE (m3/s)"); ax[1, 1].set_ylabel("cumulative fraction")
+    ax[1, 1].grid(True, alpha=0.25); ax[1, 1].legend(fontsize=9)
+
+    fig.suptitle(f"NWM discharge agreement: {a.label}", fontsize=13, fontweight="bold")
+    fig.savefig(f"{a.out_prefix}_summary_panels.png", dpi=100, bbox_inches="tight")
+    plt.close(fig)
+
+    print(f"aligned {offh:+.1f}h, {nt} steps x {ns} sources")
+    print(f"total resid: mean={resid.mean():+.2f} rms={np.sqrt((resid**2).mean()):.2f} m3/s")
+    print(f"cumulative volume ops={vol_o[-1]:.4f} ufs={vol_u[-1]:.4f} km3 ({pct:+.3f}%)")
+    print(f"per-source RMSE (active): median={med:.4g} 95th={p95:.4g} max={pr.max():.4g} m3/s")
+    print(f"saved {a.out_prefix}_top16_hydrographs.png, {a.out_prefix}_summary_panels.png")
+
+
+if __name__ == "__main__":
+    main()

--- a/SECOFS-UFS-DATM-VALIDATION/plot_nwm_vsource_compare.py
+++ b/SECOFS-UFS-DATM-VALIDATION/plot_nwm_vsource_compare.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""
+NWM river source comparison: operational vs UFS, from vsource.th
+(col0=time(s), cols1..N = per-source volume discharge m3/s). Diagnoses whether
+the primary (NWM) river forcing matches source-by-source.
+
+Auto-aligns any nowcast-window offset (cross-correlation on active sources).
+
+Usage:
+  python3 plot_nwm_vsource_compare.py OPS_vsource.th UFS_vsource.th \
+      [--out nwm.png] [--label "..."] [--maxlag 24] [--topn 6]
+"""
+import argparse
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+ACTIVE = 0.011   # > this (m3/s) counts as an active source (0.01 is the placeholder)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("ops"); ap.add_argument("ufs")
+    ap.add_argument("--out", default="nwm_vsource_compare.png")
+    ap.add_argument("--label", default="operational vs UFS")
+    ap.add_argument("--maxlag", type=int, default=24, help="max align lag (steps)")
+    ap.add_argument("--topn", type=int, default=6)
+    a = ap.parse_args()
+
+    O = np.loadtxt(a.ops); U = np.loadtxt(a.ufs)
+    qo, qu = O[:, 1:], U[:, 1:]
+    ns = min(qo.shape[1], qu.shape[1]); qo, qu = qo[:, :ns], qu[:, :ns]
+    dt = (O[1, 0] - O[0, 0]) if len(O) > 1 else 3600.0
+
+    # auto-align on active sources (those that vary in time)
+    act = (qo.max(0) > ACTIVE)
+    best = (0, np.inf)
+    for lag in range(-a.maxlag, a.maxlag + 1):
+        if lag >= 0:
+            A = qo[lag:][:, act]; B = qu[:A.shape[0]][:, act]
+        else:
+            A = qo[:qu.shape[0] + lag][:, act]; B = qu[-lag:][:, act]
+        n = min(A.shape[0], B.shape[0])
+        if n < 5:
+            continue
+        rr = np.sqrt(np.nanmean((A[:n] - B[:n]) ** 2))
+        if rr < best[1]:
+            best = (lag, rr)
+    lag = best[0]; off_h = lag * dt / 3600.0
+    if lag >= 0:
+        qo, qu = qo[lag:], qu[:qo.shape[0] - lag]
+    else:
+        qo, qu = qo[:qu.shape[0] + lag], qu[-lag:]
+    nt = min(qo.shape[0], qu.shape[0]); qo, qu = qo[:nt], qu[:nt]
+    hrs = np.arange(nt) * dt / 3600.0
+
+    diff = qu - qo
+    rmse = float(np.sqrt(np.nanmean(diff ** 2)))
+    permax = np.nanmax(np.abs(diff), axis=0)        # per-source max|diff|
+    n_diff = int((permax > ACTIVE).sum())
+    moq = qo.mean(0); muq = qu.mean(0)
+    top = np.argsort(np.maximum(moq, muq))[::-1][:a.topn]
+
+    fig, ax = plt.subplots(2, 2, figsize=(16, 10), constrained_layout=True)
+
+    ax[0, 0].plot(hrs, qo.sum(1), color="blue", lw=1.8, label="operational")
+    ax[0, 0].plot(hrs, qu.sum(1), color="red", lw=1.2, ls="--", label="UFS")
+    ax[0, 0].set_title(f"Total discharge (sum of {ns} sources)")
+    ax[0, 0].set_xlabel("Time (hours)"); ax[0, 0].set_ylabel("m3/s")
+    ax[0, 0].grid(True, alpha=0.25); ax[0, 0].legend()
+
+    lim = max(moq.max(), muq.max()) * 1.05
+    ax[0, 1].scatter(moq, muq, s=8, alpha=0.5, edgecolors="none")
+    ax[0, 1].plot([0, lim], [0, lim], "k--", lw=1, alpha=0.6)
+    ax[0, 1].set_title(f"Per-source mean discharge (1:1)   sources differing: {n_diff}/{int(act.sum())} active")
+    ax[0, 1].set_xlabel("operational (m3/s)"); ax[0, 1].set_ylabel("UFS (m3/s)")
+    ax[0, 1].grid(True, alpha=0.25)
+
+    sp = np.sort(permax[permax > 1e-6])[::-1]
+    ax[1, 0].semilogy(np.arange(1, len(sp) + 1), sp, lw=1.4)
+    ax[1, 0].axhline(ACTIVE, color="r", ls="--", lw=0.8, label=f"active thresh {ACTIVE}")
+    ax[1, 0].set_title("Per-source max|diff| (sorted, log)")
+    ax[1, 0].set_xlabel("source rank"); ax[1, 0].set_ylabel("max|diff| m3/s")
+    ax[1, 0].grid(True, alpha=0.25); ax[1, 0].legend(fontsize=8)
+
+    for k in top:
+        ax[1, 1].plot(hrs, qo[:, k], lw=1.5, label=f"src{k} ops")
+        ax[1, 1].plot(hrs, qu[:, k], lw=1.0, ls="--", color="k", alpha=0.6)
+    ax[1, 1].set_title(f"Top {a.topn} sources (ops solid, ufs black dashed)")
+    ax[1, 1].set_xlabel("Time (hours)"); ax[1, 1].set_ylabel("m3/s")
+    ax[1, 1].grid(True, alpha=0.25); ax[1, 1].legend(fontsize=8, ncol=2)
+
+    fig.suptitle(f"NWM vsource discharge: {a.label}\n"
+                 f"aligned (offset {off_h:+.1f}h), {nt} steps x {ns} sources   "
+                 f"RMSE={rmse:.4g} m3/s   total-Q diff: "
+                 f"{abs(qu.sum(1).mean() - qo.sum(1).mean()):.2f} m3/s   "
+                 f"sources differing>{ACTIVE}: {n_diff}",
+                 fontsize=13, fontweight="bold")
+    fig.savefig(a.out, dpi=130, bbox_inches="tight")
+    print(f"saved {a.out}  offset={off_h:+.1f}h RMSE={rmse:.4g} n_diff={n_diff} "
+          f"totalQ ops={qo.sum(1).mean():.1f} ufs={qu.sum(1).mean():.1f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/SECOFS-UFS-DATM-VALIDATION/plot_river_flux_compare.py
+++ b/SECOFS-UFS-DATM-VALIDATION/plot_river_flux_compare.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""
+River flow-boundary forcing comparison: operational vs UFS, from schism_flux.th
+(SCHISM flow-boundary discharge; col0=time(s), cols1..N = per-river flux m3/s,
+negative = inflow). This is the COMF river.ctl open-boundary USGS river family,
+SEPARATE from the NWM vsource source/sink family (see plot_nwm_vsource_compare.py).
+Auto-aligns the nowcast-window offset (same structural shift as OBC).
+
+Usage:
+  python3 plot_river_flux_compare.py OPS_schism_flux.th UFS_schism_flux.th \
+      [--out river.png] [--label "..."] [--maxlag 300] [--unit "m3/s"]
+"""
+import argparse
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("ops"); ap.add_argument("ufs")
+    ap.add_argument("--out", default="river_flux_compare.png")
+    ap.add_argument("--label", default="operational vs UFS")
+    ap.add_argument("--maxlag", type=int, default=300)
+    ap.add_argument("--unit", default="m3/s")
+    a = ap.parse_args()
+
+    O = np.loadtxt(a.ops); U = np.loadtxt(a.ufs)
+    to, fo = O[:, 0], O[:, 1:]
+    tu, fu = U[:, 0], U[:, 1:]
+    nr = min(fo.shape[1], fu.shape[1]); fo, fu = fo[:, :nr], fu[:, :nr]
+    dt = (to[1] - to[0]) if len(to) > 1 else 3600.0
+
+    # River flux is typically ~constant (climatological flow boundary), so
+    # cross-correlation is unreliable. The windows differ only in leading
+    # lookback (same structural offset as OBC), so END-align: keep the last nt
+    # steps of each (both end at cycle+forecast).
+    nt = min(fo.shape[0], fu.shape[0])
+    off_h = (max(fo.shape[0], fu.shape[0]) - nt) * dt / 3600.0
+    fo, fu = fo[-nt:], fu[-nt:]
+    hrs = np.arange(nt) * dt / 3600.0
+
+    rmse = float(np.sqrt(np.nanmean((fu - fo) ** 2)))
+    mx = float(np.nanmax(np.abs(fu - fo)))
+
+    ncol = min(3, nr); nrow = int(np.ceil(nr / ncol))
+    fig, ax = plt.subplots(nrow, ncol, figsize=(6 * ncol, 3.4 * nrow),
+                           constrained_layout=True, squeeze=False)
+    for k in range(nrow * ncol):
+        r, c = divmod(k, ncol); axk = ax[r][c]
+        if k >= nr:
+            axk.axis("off"); continue
+        axk.plot(hrs, fo[:, k], color="blue", lw=1.6, label="operational")
+        axk.plot(hrs, fu[:, k], color="red", lw=1.1, ls="--", label="UFS")
+        rk = np.sqrt(np.nanmean((fu[:, k] - fo[:, k]) ** 2))
+        axk.set_title(f"river {k + 1}   RMSE={rk:.3g} {a.unit}", fontsize=10)
+        axk.set_xlabel("Time (hours)"); axk.set_ylabel(a.unit)
+        axk.grid(True, alpha=0.25); axk.legend(fontsize=8)
+    fig.suptitle(f"River flow-boundary flux: {a.label}\n"
+                 f"end-aligned (window diff {off_h:.1f}h), {nt} steps x {nr} cols   "
+                 f"RMSE={rmse:.4g}  max|diff|={mx:.4g} {a.unit}",
+                 fontsize=14, fontweight="bold")
+    fig.savefig(a.out, dpi=130, bbox_inches="tight")
+    print(f"saved {a.out}  (offset {off_h:+.1f}h, RMSE={rmse:.4g}, max={mx:.4g})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds the river/NWM verification tools to the SECOFS-UFS validation set (the DATM, HRRR, OBC, and tides tools were added in earlier PRs).

- `plot_nwm_vsource_compare.py` - NWM source/sink `vsource.th` operational-vs-UFS comparison (4 panels: total discharge overlay, per-source 1:1 mean scatter, sorted per-source max|diff|, top-N source hydrographs). Auto-aligns the nowcast-window offset via cross-correlation.
- `plot_discharge_extra.py` - deeper discharge cuts: top-N per-source hydrographs with per-panel RMSE/correlation, plus total/residual/cumulative-delivered-volume and a per-source RMSE ECDF. CLI-driven (`OPS UFS [--source-sink ... --out-prefix ... --topn ...]`).
- `plot_river_flux_compare.py` - `schism_flux.th` open-boundary (USGS `river.ctl`) flux comparison; end-aligns the flat climatological signals.

All CLI-driven, `matplotlib(Agg)`, memory-frugal (run under `ulimit -v` on WCOSS2). These validated the NWM river vsource forecast-blend fix: per-source RMSE 0.30 m3/s (was ~12.6 pre-fix), cumulative delivered volume within 0.27% on the 20260618 12z cycle.
