### PR TITLE
Add 3D OBC validation scripts (TEM/SAL/uv boundary, operational vs UFS)

### DIFF
--- a/SECOFS-UFS-DATM-VALIDATION/plot_obc_3d_boundary_map.py
+++ b/SECOFS-UFS-DATM-VALIDATION/plot_obc_3d_boundary_map.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""
+OBC 3D BOUNDARY MAP: operational vs UFS vs diff, depth-resolved, for the SCHISM
+*_3D.th.nc files (TEM_3D / SAL_3D / uv3D). Plots a chosen vertical level on the
+open-boundary nodes (lon/lat from hgrid.gr3) at several time snapshots - the
+depth analog of plot_obc_ssh_boundary_map.py.
+
+The *_3D.th.nc files carry no coordinates, so open-boundary node lon/lat are
+pulled from the SECOFS hgrid.gr3 (open boundaries 1..nbnd) and cached to a small
+.npz (the 321 MB hgrid is parsed only once). The 3D node set is the same 1488
+elevation-forced boundary nodes as elev2D, so the cache is shared.
+
+The 3D files are coarse (3-hourly) and offset from ufs by the nowcast lookback;
+TEM aligns cleanly, but pass --offset-hours (the value TEM finds, e.g. 6) for the
+smooth SAL field and the zero uv field, which do not cross-correlate reliably.
+
+Usage:
+  python3 plot_obc_3d_boundary_map.py OPS_TEM_3D.th.nc UFS_TEM_3D.th.nc \
+      --hgrid /path/to/hgrid.gr3 [--level -1] [--var auto] [--nbnd 3] \
+      [--offset-hours 6] [--snaps 0,8,16] [--out map.png]
+"""
+import argparse
+import os
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+from netCDF4 import Dataset
+
+UNITS = {"TEM": "degC", "SAL": "psu", "uv": "m/s"}
+
+
+def detect_var(path, override):
+    if override and override != "auto":
+        return override
+    b = os.path.basename(path).upper()
+    return ("TEM" if "TEM" in b else "SAL" if "SAL" in b
+            else "uv" if "UV" in b else "TEM")
+
+
+def boundary_coords(hgrid, nbnd, cache):
+    """Open-boundary node lon/lat from hgrid.gr3 (boundaries 1..nbnd), cached."""
+    if cache and os.path.exists(cache):
+        z = np.load(cache); return z["lon"], z["lat"]
+    if not hgrid:
+        raise SystemExit("need --hgrid (or an existing --cache .npz)")
+    with open(hgrid) as f:
+        f.readline()
+        ne, nn = (int(x) for x in f.readline().split()[:2])
+        lon = np.empty(nn); lat = np.empty(nn)
+        for i in range(nn):
+            p = f.readline().split(); lon[i] = float(p[1]); lat[i] = float(p[2])
+        for _ in range(ne):
+            f.readline()
+        n_open = int(f.readline().split()[0]); f.readline()  # n_open ; total
+        ids = []
+        for b in range(n_open):
+            cnt = int(f.readline().split()[0])
+            bids = [int(f.readline().split()[0]) for _ in range(cnt)]
+            if b < nbnd:
+                ids.extend(bids)
+    idx = np.array(ids) - 1
+    blon, blat = lon[idx], lat[idx]
+    if cache:
+        np.savez(cache, lon=blon, lat=blat)
+    return blon, blat
+
+
+def to_metric(ts, var, comp):
+    if ts.shape[-1] == 1:
+        return ts[..., 0]
+    if var == "uv" and comp is None:
+        return np.hypot(ts[..., 0], ts[..., 1])
+    return ts[..., comp]
+
+
+def load_level(path, level, var, comp):
+    ds = Dataset(path)
+    ts = np.array(ds.variables["time_series"][:], dtype="f8")
+    dt = (float(np.diff(ds.variables["time"][:2])[0])
+          if "time" in ds.variables and len(ds.variables["time"]) > 1 else 10800.0)
+    ds.close()
+    while ts.ndim < 4:
+        ts = ts[..., None]
+    return to_metric(ts, var, comp)[:, :, level], dt   # (T, N), dt
+
+
+def align_lag(o, u, dt, offset_hours, maxlag):
+    if offset_hours is not None:
+        return int(round(offset_hours * 3600.0 / dt))
+    sub = slice(0, o.shape[1], max(1, o.shape[1] // 40))
+    os_, us_ = o[:, sub], u[:, sub]
+    mo = max(4, min(os_.shape[0], us_.shape[0]) // 2); best = (0, np.inf)
+    for lag in range(-maxlag, maxlag + 1):
+        if lag >= 0:
+            A = os_[lag:]; B = us_[:A.shape[0]]
+        else:
+            A = os_[:us_.shape[0] + lag]; B = us_[-lag:]
+        n = min(A.shape[0], B.shape[0])
+        if n < mo:
+            continue
+        rr = np.sqrt(np.nanmean((A[:n] - B[:n]) ** 2))
+        if rr < best[1]:
+            best = (lag, rr)
+    return best[0]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("ops"); ap.add_argument("ufs")
+    ap.add_argument("--hgrid", default=None)
+    ap.add_argument("--nbnd", type=int, default=3, help="num elevation-forced open boundaries")
+    ap.add_argument("--cache", default="secofs_obc_bnd_coords.npz")
+    ap.add_argument("--level", type=int, default=-1, help="vertical level (-1=surface, 0=bottom)")
+    ap.add_argument("--var", default="auto")
+    ap.add_argument("--component", type=int, default=None, help="uv: 0=u, 1=v; default speed")
+    ap.add_argument("--offset-hours", type=float, default=None,
+                    help="force ops->ufs lag in hours (use for SAL/uv)")
+    ap.add_argument("--maxlag", type=int, default=400)
+    ap.add_argument("--snaps", default=None, help="comma time-indices (default 3 evenly spaced)")
+    ap.add_argument("--out", default="obc_3d_boundary_map.png")
+    ap.add_argument("--label", default="operational vs UFS")
+    a = ap.parse_args()
+
+    var = detect_var(a.ops, a.var); unit = UNITS.get(var, "")
+    lon, lat = boundary_coords(a.hgrid, a.nbnd, a.cache)
+    O, dt = load_level(a.ops, a.level, var, a.component)
+    U, _ = load_level(a.ufs, a.level, var, a.component)
+    lag = align_lag(O, U, dt, a.offset_hours, a.maxlag); off_h = lag * dt / 3600.0
+    if lag >= 0:
+        O, U = O[lag:], U[:O.shape[0] - lag]
+    else:
+        O, U = O[:U.shape[0] + lag], U[-lag:]
+    nt = min(O.shape[0], U.shape[0]); O, U = O[:nt], U[:nt]
+    nn = min(O.shape[1], U.shape[1], len(lon))
+    O, U, lon, lat = O[:, :nn], U[:, :nn], lon[:nn], lat[:nn]
+    print(f"var={var} level={a.level} nodes={nn} steps={nt} offset={off_h:+.1f}h "
+          f"lon[{lon.min():.1f},{lon.max():.1f}] lat[{lat.min():.1f},{lat.max():.1f}]")
+
+    snaps = ([int(x) for x in a.snaps.split(",")] if a.snaps
+             else [0, nt // 2, nt - 1])
+    snaps = [s for s in snaps if s < nt]
+    vmin = min(np.nanmin(O), np.nanmin(U)); vmax = max(np.nanmax(O), np.nanmax(U))
+    dmax = max(np.nanmax(np.abs(U - O)), 1e-6)
+
+    fig, ax = plt.subplots(len(snaps), 3, figsize=(15, 4.4 * len(snaps)),
+                           constrained_layout=True)
+    if len(snaps) == 1:
+        ax = ax[None, :]
+    for r, ti in enumerate(snaps):
+        rm = np.sqrt(np.nanmean((U[ti] - O[ti]) ** 2))
+        for c, (dat, ttl, cmap, vlo, vhi, cl) in enumerate([
+                (O[ti], "operational", "viridis", vmin, vmax, f"{var} ({unit})"),
+                (U[ti], "UFS", "viridis", vmin, vmax, f"{var} ({unit})"),
+                (U[ti] - O[ti], "diff (UFS-ops)", "bwr", -dmax, dmax, unit)]):
+            sc = ax[r, c].scatter(lon, lat, c=dat, s=6, cmap=cmap, vmin=vlo, vmax=vhi)
+            plt.colorbar(sc, ax=ax[r, c], fraction=0.046, pad=0.04, label=cl)
+            ttl2 = ttl + (f"  step {ti}" if c == 0 else
+                          (f"  RMSE={rm:.3g} {unit}" if c == 2 else ""))
+            ax[r, c].set_title(ttl2, fontsize=10)
+            ax[r, c].set_xlabel("lon"); ax[r, c].set_ylabel("lat")
+    lvlname = ("surface" if a.level == -1 else
+               "bottom" if a.level == 0 else f"level {a.level}")
+    fig.suptitle(f"OBC {var} @ {lvlname} on open-boundary nodes ({nn}): {a.label}\n"
+                 f"aligned {off_h:+.1f}h, {nt} steps",
+                 fontsize=14, fontweight="bold")
+    fig.savefig(a.out, dpi=130, bbox_inches="tight")
+    print("saved", a.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/SECOFS-UFS-DATM-VALIDATION/plot_obc_3d_compare.py
+++ b/SECOFS-UFS-DATM-VALIDATION/plot_obc_3d_compare.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""
+OBC 3D boundary forcing comparison (depth-aware): operational (secofs) vs UFS
+(secofs_ufs), for the SCHISM *_3D.th.nc files:
+
+  TEM_3D.th.nc  temperature (degC,  ncomp=1)
+  SAL_3D.th.nc  salinity    (psu,   ncomp=1)
+  uv3D.th.nc    velocity    (m/s,   ncomp=2 -> u, v; default metric = speed)
+
+Layout (same as elev2D): variable `time_series` with dims
+(time, nOpenBndNodes, nLevels, nComponents). Extract the file from obc.tar first:
+  tar -xf <obc.tar> TEM_3D.th.nc
+
+Auto-aligns the nowcast-window offset by cross-correlation (no base_date in file).
+
+Panels: domain-mean(t), per-level RMSE, depth profile at a node, surface
+time-series at a node.
+
+Usage:
+  python3 plot_obc_3d_compare.py OPS_TEM_3D.th.nc UFS_TEM_3D.th.nc \
+      [--out tem.png] [--var auto|TEM|SAL|uv] [--component -1] \
+      [--node 700] [--nodes 0,500,1000,1400] [--maxlag 400] [--label "..."]
+"""
+import argparse
+import os
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+from netCDF4 import Dataset
+
+UNITS = {"TEM": "degC", "SAL": "psu", "uv": "m/s"}
+
+
+def detect_var(path, override):
+    if override and override != "auto":
+        return override
+    b = os.path.basename(path).upper()
+    if "TEM" in b:
+        return "TEM"
+    if "SAL" in b:
+        return "SAL"
+    if "UV" in b:
+        return "uv"
+    return "TEM"
+
+
+def load(path):
+    """Return (time[s], time_series(T, N, L, C))."""
+    ds = Dataset(path)
+    ts = np.array(ds.variables["time_series"][:], dtype="f8")
+    while ts.ndim < 4:
+        ts = ts[..., None]
+    if "time" in ds.variables:
+        t = np.array(ds.variables["time"][:], dtype="f8")
+    elif "time_step" in ds.variables:
+        dt = float(np.array(ds.variables["time_step"][:]).ravel()[0])
+        t = np.arange(ts.shape[0]) * dt
+    else:
+        t = np.arange(ts.shape[0], dtype="f8")
+    ds.close()
+    return t, ts
+
+
+def to_metric(ts, var, comp):
+    """Collapse the component axis to a single scalar field (T, N, L)."""
+    if ts.shape[-1] == 1:
+        return ts[..., 0]
+    if var == "uv" and comp is None:
+        return np.hypot(ts[..., 0], ts[..., 1])      # speed
+    return ts[..., comp]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("ops"); ap.add_argument("ufs")
+    ap.add_argument("--out", default="obc_3d_compare.png")
+    ap.add_argument("--var", default="auto", help="auto|TEM|SAL|uv")
+    ap.add_argument("--component", type=int, default=None,
+                    help="uv: 0=u, 1=v; default None=speed")
+    ap.add_argument("--node", type=int, default=None, help="node for depth profile")
+    ap.add_argument("--nodes", default="0,500,1000,1400")
+    ap.add_argument("--maxlag", type=int, default=400)
+    ap.add_argument("--offset-hours", type=float, default=None,
+                    help="force the ops->ufs window lag in hours and skip "
+                         "auto-align. Use the value TEM_3D finds (the smooth "
+                         "SAL field and the zero uv field do not cross-correlate "
+                         "reliably; all OBC vars share the same tar time base).")
+    ap.add_argument("--label", default="operational (secofs) vs UFS (secofs_ufs)")
+    a = ap.parse_args()
+
+    var = detect_var(a.ops, a.var)
+    unit = UNITS.get(var, "")
+    to, Oraw = load(a.ops); tu, Uraw = load(a.ufs)  # (T, N, L, C)
+    nN = min(Oraw.shape[1], Uraw.shape[1]); nL = min(Oraw.shape[2], Uraw.shape[2])
+    Oraw, Uraw = Oraw[:, :nN, :nL], Uraw[:, :nN, :nL]
+    dt = (to[1] - to[0]) if len(to) > 1 else 120.0
+
+    # AUTO-ALIGN in time (windows differ in nowcast lookback; no base_date in
+    # file). Lock onto the SURFACE level of the FIRST component: it is
+    # directional and aligns uniquely, whereas speed (sqrt(u^2+v^2)) halves the
+    # tidal period and can alias to a wrong lag.
+    surf = nL - 1
+    if a.offset_hours is not None:
+        lag = int(round(a.offset_hours * 3600.0 / dt))
+    else:
+        sub = slice(0, nN, max(1, nN // 40))
+        os_, us_ = Oraw[:, sub, surf, 0], Uraw[:, sub, surf, 0]
+        # Require at least half the shorter series to overlap. The 3D OBC files
+        # are coarse (3-hourly, ~18 steps), so a fixed large floor would skip
+        # every lag and leave the windows unaligned; elev2D-style 120s files
+        # (~1600 steps) still get a meaningful floor.
+        min_overlap = max(4, min(os_.shape[0], us_.shape[0]) // 2)
+        best = (0, np.inf)
+        for lag in range(-a.maxlag, a.maxlag + 1):
+            if lag >= 0:
+                A = os_[lag:]; B = us_[:A.shape[0]]
+            else:
+                A = os_[:us_.shape[0] + lag]; B = us_[-lag:]
+            n = min(A.shape[0], B.shape[0])
+            if n < min_overlap:
+                continue
+            rr = np.sqrt(np.nanmean((A[:n] - B[:n]) ** 2))
+            if rr < best[1]:
+                best = (lag, rr)
+        lag = best[0]
+    off_h = lag * dt / 3600.0
+    if lag >= 0:
+        Oraw, Uraw = Oraw[lag:], Uraw[:Oraw.shape[0] - lag]
+    else:
+        Oraw, Uraw = Oraw[:Uraw.shape[0] + lag], Uraw[-lag:]
+    nt = min(Oraw.shape[0], Uraw.shape[0]); Oraw, Uraw = Oraw[:nt], Uraw[:nt]
+    O = to_metric(Oraw, var, a.component); U = to_metric(Uraw, var, a.component)  # (T,N,L)
+    hrs = np.arange(nt) * dt / 3600.0
+
+    diff = U - O
+    rmse = float(np.sqrt(np.nanmean(diff ** 2)))
+    maxd = float(np.nanmax(np.abs(diff)))
+    with np.errstate(invalid="ignore"):
+        r = np.corrcoef(O.ravel(), U.ravel())[0, 1]
+    near_zero = max(np.nanmax(np.abs(O)), np.nanmax(np.abs(U))) < 1e-9
+    zero_note = "   [both fields ~0: no forcing, trivial parity]" if near_zero else ""
+
+    node = a.node if a.node is not None else nN // 2
+    nodes = [int(x) for x in a.nodes.split(",") if int(x) < nN]
+
+    fig, ax = plt.subplots(2, 2, figsize=(16, 9), constrained_layout=True)
+
+    # [0,0] domain-mean over time (mean over all nodes + levels)
+    ax[0, 0].plot(hrs, O.mean((1, 2)), color="blue", lw=1.8, label="operational")
+    ax[0, 0].plot(hrs, U.mean((1, 2)), color="red", lw=1.2, ls="--", label="UFS")
+    ax[0, 0].set_title(f"Domain-mean {var} over time")
+    ax[0, 0].set_xlabel("Time (hours)"); ax[0, 0].set_ylabel(f"{var} ({unit})")
+    ax[0, 0].grid(True, alpha=0.25); ax[0, 0].legend()
+
+    # [0,1] per-level RMSE (mean over nodes + time)
+    lvl_rmse = np.sqrt(np.nanmean(diff ** 2, axis=(0, 1)))   # (L,)
+    ax[0, 1].plot(lvl_rmse, np.arange(nL), color="purple", lw=1.6, marker="o", ms=3)
+    ax[0, 1].set_title("Per-level RMSE (mean over nodes & time)")
+    ax[0, 1].set_xlabel(f"RMSE ({unit})"); ax[0, 1].set_ylabel("level index (0=bottom)")
+    ax[0, 1].grid(True, alpha=0.25)
+
+    # [1,0] depth profile at `node` at mid-time
+    mt = nt // 2
+    ax[1, 0].plot(O[mt, node, :], np.arange(nL), color="blue", lw=1.8, marker="o",
+                  ms=3, label="operational")
+    ax[1, 0].plot(U[mt, node, :], np.arange(nL), color="red", lw=1.2, ls="--",
+                  marker="s", ms=3, label="UFS")
+    ax[1, 0].set_title(f"Depth profile @ node {node}, t={hrs[mt]:.0f}h")
+    ax[1, 0].set_xlabel(f"{var} ({unit})"); ax[1, 0].set_ylabel("level index (0=bottom)")
+    ax[1, 0].grid(True, alpha=0.25); ax[1, 0].legend()
+
+    # [1,1] surface time-series at sample nodes
+    for nd in nodes:
+        ax[1, 1].plot(hrs, O[:, nd, surf], lw=1.5, label=f"ops n{nd}")
+        ax[1, 1].plot(hrs, U[:, nd, surf], lw=1.0, ls="--", color="k", alpha=0.6)
+    ax[1, 1].set_title(f"Surface-level {var} (ops solid, ufs black dashed)")
+    ax[1, 1].set_xlabel("Time (hours)"); ax[1, 1].set_ylabel(f"{var} ({unit})")
+    ax[1, 1].grid(True, alpha=0.25); ax[1, 1].legend(fontsize=8, ncol=2)
+
+    metric = "speed" if (var == "uv" and a.component is None) else \
+        (f"component {a.component}" if a.component is not None else var)
+    fig.suptitle(f"OBC {var} ({metric}) boundary: {a.label}\n"
+                 f"aligned {off_h:+.1f}h, {nt} steps x {nN} nodes x {nL} levels   "
+                 f"RMSE={rmse:.4g} {unit}   max|diff|={maxd:.4g}   R={r:.6f}{zero_note}",
+                 fontsize=13, fontweight="bold")
+    fig.savefig(a.out, dpi=120, bbox_inches="tight")
+    print(f"saved {a.out}  var={var} offset={off_h:+.1f}h RMSE={rmse:.4g} {unit} "
+          f"max={maxd:.4g} R={r:.6f} shape=({nt},{nN},{nL})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Extends the OBC validation tooling from 2D SSH (`elev2D`) to the depth-resolved 3D boundary files (`TEM_3D` / `SAL_3D` / `uv3D.th.nc`).

Both read the SCHISM `time_series(time, node, level, comp)` layout, handle the coarse 3-hourly cadence (adaptive overlap floor), and auto-align the nowcast-window offset on the first component (avoids speed-aliasing for velocity); use `--offset-hours` for the smooth SAL field and the zero uv field, which do not cross-correlate reliably (all OBC vars share the same tar time base).

- `plot_obc_3d_compare.py` - per-variable comparison (`--var auto|TEM|SAL|uv`, `--component` for uv). Panels: domain-mean over time, per-level RMSE, depth profile at a node, surface time-series. Marks ~zero fields (uv) as trivial parity.
- `plot_obc_3d_boundary_map.py` - depth-resolved spatial map (ops / ufs / diff scatter on the open-boundary nodes) at a chosen `--level`; reuses the elev2D boundary-coordinate cache (hgrid open-boundary lon/lat to a shared `.npz`).

## Validation (20260618 12z, ops vs UFS)

- `TEM_3D`: RMSE 0.60 degC, R=0.997; differences concentrate in the thermocline, profile structure matches.
- `SAL_3D`: RMSE 0.14 psu, R=0.982; deep water ~0.07 psu, surface up to ~0.24 psu.
- `uv3D`: all zeros on both sides (SECOFS does not force boundary velocity) - exact parity by construction.

Completes the SECOFS-UFS forcing validation set: DATM, HRRR, NWM river, tides, and OBC (SSH + 3D T/S/uv).
